### PR TITLE
add explicit dependency

### DIFF
--- a/examples/adb-basic/main.tf
+++ b/examples/adb-basic/main.tf
@@ -39,6 +39,7 @@ locals {
 
 data "databricks_spark_version" "latest_lts" {
   long_term_support = true
+  depends_on        = [azurerm_databricks_workspace.example]
 }
 
 


### PR DESCRIPTION
`terraform plan/appy` throw `io.jsonwebtoken.ExpiredJwtException` without an explicit dependency on `databricks_spark_version.latest_lts` for `azurerm_databricks_workspace.example`