### PR TITLE
update dfs in azure

### DIFF
--- a/modules/adb-exfiltration-protection/firewall.tf
+++ b/modules/adb-exfiltration-protection/firewall.tf
@@ -102,7 +102,7 @@ resource "azurerm_firewall_application_rule_collection" "adbfqdn" {
       join(", ", azurerm_subnet.private.address_prefixes),
     ]
 
-    target_fqdns = ["${local.dbfsname}.blob.core.windows.net"]
+    target_fqdns = ["${local.dbfsname}.dfs.core.windows.net"]
 
     protocol {
       port = "443"

--- a/modules/adb-with-private-link-standard/endpoint_dbfs.tf
+++ b/modules/adb-with-private-link-standard/endpoint_dbfs.tf
@@ -9,7 +9,7 @@ resource "azurerm_private_endpoint" "dp_dbfspe" {
     name                           = "ple-${local.prefix}-dp-dbfs"
     private_connection_resource_id = join("", [azurerm_databricks_workspace.dp_workspace.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${local.dbfsname}"])
     is_manual_connection           = false
-    subresource_names              = ["blob"]
+    subresource_names              = ["dfs"]
   }
 
   private_dns_zone_group {

--- a/modules/adb-with-private-link-standard/private_dns_zone_dp.tf
+++ b/modules/adb-with-private-link-standard/private_dns_zone_dp.tf
@@ -11,7 +11,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "dpcpdnszonevnetlink" {
 }
 
 resource "azurerm_private_dns_zone" "dnsdbfs" {
-  name                = "privatelink.blob.core.windows.net"
+  name                = "privatelink.dfs.core.windows.net"
   resource_group_name = azurerm_resource_group.dp_rg.name
 }
 

--- a/modules/adb-with-private-links-exfiltration-protection/privateendpoint.tf
+++ b/modules/adb-with-private-links-exfiltration-protection/privateendpoint.tf
@@ -61,7 +61,7 @@ resource "azurerm_private_endpoint" "dbfspe" {
     name                           = "ple-${var.workspace_prefix}-dbfs"
     private_connection_resource_id = join("", [azurerm_databricks_workspace.this.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${local.dbfsname}"])
     is_manual_connection           = false
-    subresource_names              = ["blob"]
+    subresource_names              = ["dfs"]
   }
 
   private_dns_zone_group {
@@ -70,7 +70,7 @@ resource "azurerm_private_endpoint" "dbfspe" {
   }
 }
 resource "azurerm_private_dns_zone" "dnsdbfs" {
-  name                = "privatelink.blob.core.windows.net"
+  name                = "privatelink.dfs.core.windows.net"
   resource_group_name = azurerm_resource_group.this.name
 }
 


### PR DESCRIPTION
Due to https://learn.microsoft.com/en-us/azure/databricks/release-notes/product/2023/march#--azure-databricks-dbfs-root-storage-uses-azure-data-lake-storage-gen2-for-new-workspaces 

This PR will use 'dfs' for DBFS root in private link, instead of 'blob'.