### PR TITLE
Add minor fixes to adb-with-private-link-standard

### DIFF
--- a/examples/adb-with-private-link-standard/main.tf
+++ b/examples/adb-with-private-link-standard/main.tf
@@ -1,5 +1,5 @@
 module "adb-with-private-link-standard" {
-  source       = "github.com/databricks/terraform-databricks-examples/modules/adb-with-private-link-standard"
+  source       = "../../modules/adb-with-private-link-standard"
   cidr_transit = var.cidr_transit
   cidr_dp      = var.cidr_dp
   location     = var.location

--- a/examples/adb-with-private-link-standard/main.tf
+++ b/examples/adb-with-private-link-standard/main.tf
@@ -1,5 +1,5 @@
 module "adb-with-private-link-standard" {
-  source       = "../../modules/adb-with-private-link-standard"
+  source       = "github.com/databricks/terraform-databricks-examples/modules/adb-with-private-link-standard"
   cidr_transit = var.cidr_transit
   cidr_dp      = var.cidr_dp
   location     = var.location

--- a/examples/adb-with-private-link-standard/outputs.tf
+++ b/examples/adb-with-private-link-standard/outputs.tf
@@ -1,0 +1,9 @@
+output "databricks_workspace_url" {
+  value = module.adb-with-private-link-standard.dp_workspace_url
+}
+
+output "test_vm_password" {
+  description = "Password to access the VM, use `terraform output -json test_vm_password` to get the password value"
+  value = module.adb-with-private-link-standard.test_vm_password
+  sensitive = true
+}

--- a/examples/adb-with-private-link-standard/outputs.tf
+++ b/examples/adb-with-private-link-standard/outputs.tf
@@ -1,9 +1,5 @@
-output "databricks_workspace_url" {
-  value = module.adb-with-private-link-standard.dp_workspace_url
-}
-
 output "test_vm_password" {
-  description = "Password to access the VM, use `terraform output -json test_vm_password` to get the password value"
+  description = "Password to access the Test VM, use `terraform output -json test_vm_password` to get the password value"
   value = module.adb-with-private-link-standard.test_vm_password
   sensitive = true
 }

--- a/modules/adb-with-private-link-standard/endpoint_webauth.tf
+++ b/modules/adb-with-private-link-standard/endpoint_webauth.tf
@@ -34,7 +34,7 @@ resource "azurerm_databricks_workspace" "transit_workspace" {
     public_subnet_name                                   = azurerm_subnet.transit_public.name
     public_subnet_network_security_group_association_id  = azurerm_subnet_network_security_group_association.transit_public.id
     private_subnet_network_security_group_association_id = azurerm_subnet_network_security_group_association.transit_private.id
-    storage_account_name                                 = "dbfsd723k4b3"
+    storage_account_name                                 = "${local.dbfsname}auth"
   }
   # We need this, otherwise destroy doesn't cleanup things correctly
   depends_on = [

--- a/modules/adb-with-private-link-standard/outputs.tf
+++ b/modules/adb-with-private-link-standard/outputs.tf
@@ -10,6 +10,7 @@ output "dp_workspace_url" {
 }
 
 output "test_vm_password" {
+  description = "Password to access the Test VM, use `terraform output -json test_vm_password` to get the password value"
   value = azurerm_windows_virtual_machine.testvm.admin_password
   sensitive = true
 }

--- a/modules/adb-with-private-link-standard/outputs.tf
+++ b/modules/adb-with-private-link-standard/outputs.tf
@@ -8,3 +8,8 @@ output "dp_workspace_url" {
   // this is not named as DATABRICKS_HOST, because it affect authentication
   value = "https://${azurerm_databricks_workspace.dp_workspace.workspace_url}/"
 }
+
+output "test_vm_password" {
+  value = azurerm_windows_virtual_machine.testvm.admin_password
+  sensitive = true
+}

--- a/modules/adb-with-private-link-standard/testvm_transit.tf
+++ b/modules/adb-with-private-link-standard/testvm_transit.tf
@@ -1,3 +1,9 @@
+resource "random_string" "password" {
+  special = false
+  upper   = true
+  length  = 8
+}
+
 resource "azurerm_network_interface" "testvmnic" {
   name                = "${local.prefix}-testvm-nic"
   location            = azurerm_resource_group.transit_rg.location
@@ -61,12 +67,12 @@ resource "azurerm_public_ip" "testvmpublicip" {
 }
 
 resource "azurerm_windows_virtual_machine" "testvm" {
-  name                = "${local.prefix}-test"
+  name                = "${local.prefix}vm"
   resource_group_name = azurerm_resource_group.transit_rg.name
   location            = azurerm_resource_group.transit_rg.location
   size                = "Standard_F4s_v2"
   admin_username      = "azureuser"
-  admin_password      = "TesTed567!!!"
+  admin_password      = "T${random_string.password.result}!!"
   network_interface_ids = [
     azurerm_network_interface.testvmnic.id,
   ]


### PR DESCRIPTION
1. Reduced the length of test VM's `name` property (max length is 15 characters)
2. Changed `storage_account_name` of the `transit_workspace` to dynamic value
3. Made the Test VM's `admin_password` dynamic
4. Pointed to the local copy of the module instead of the one on GitHub