### PR TITLE
Make Azure Data Factory optional for adb-lakehouse

### DIFF
--- a/examples/adb-lakehouse/variables.tf
+++ b/examples/adb-lakehouse/variables.tf
@@ -35,7 +35,8 @@ variable "databricks_workspace_name" {
 
 variable "data_factory_name" {
   type        = string
-  description = "(Required) The name of the Azure Data Factory to deploy"
+  description = "The name of the Azure Data Factory to deploy"
+  default     = ""
 }
 
 variable "key_vault_name" {

--- a/examples/adb-lakehouse/variables.tf
+++ b/examples/adb-lakehouse/variables.tf
@@ -35,7 +35,7 @@ variable "databricks_workspace_name" {
 
 variable "data_factory_name" {
   type        = string
-  description = "The name of the Azure Data Factory to deploy"
+  description = "The name of the Azure Data Factory to deploy. Won't be created if not specified"
   default     = ""
 }
 

--- a/modules/adb-lakehouse/azure_data_factory.tf
+++ b/modules/adb-lakehouse/azure_data_factory.tf
@@ -1,4 +1,6 @@
 resource "azurerm_data_factory" "adf" {
+  count               = var.data_factory_name != "" ? 1 : 0
+
   name                = var.data_factory_name
   location            = var.location
   resource_group_name = azurerm_resource_group.this.name

--- a/modules/adb-lakehouse/variables.tf
+++ b/modules/adb-lakehouse/variables.tf
@@ -35,7 +35,7 @@ variable "databricks_workspace_name" {
 
 variable "data_factory_name" {
   type        = string
-  description = "(Required) The name of the Azure Data Factory to deploy"
+  description = "The name of the Azure Data Factory to deploy"
 }
 
 variable "key_vault_name" {

--- a/modules/adb-lakehouse/variables.tf
+++ b/modules/adb-lakehouse/variables.tf
@@ -35,7 +35,8 @@ variable "databricks_workspace_name" {
 
 variable "data_factory_name" {
   type        = string
-  description = "The name of the Azure Data Factory to deploy"
+  description = "The name of the Azure Data Factory to deploy. Won't be created if not specified"
+  default     = ""
 }
 
 variable "key_vault_name" {


### PR DESCRIPTION
Azure Data Factory is not mandatory to use the Databricks Lakehouse. This PR adds a possibility to deploy the lakehouse without ADF. It turns ADF off by default if used with the adb-lakehouse example.