### PR TITLE
Add workspace_resource_id output for adb-lakehouse module

### DIFF
--- a/modules/adb-lakehouse/outputs.tf
+++ b/modules/adb-lakehouse/outputs.tf
@@ -33,6 +33,11 @@ output "workspace_id" {
   description = "ID of the Databricks workspace"
 }
 
+output "workspace_resource_id" {
+  value       = azurerm_databricks_workspace.this.id
+  description = "ID of the Databricks workspace resource"
+}
+
 output "workspace_url" {
   value       = azurerm_databricks_workspace.this.workspace_url
   description = "URL of the Databricks workspace"


### PR DESCRIPTION
azure_workspace_resource_id is needed to authenticate with service principal --> [docs](https://registry.terraform.io/providers/databricks/databricks/latest/docs#authenticating-with-azure-service-principal) 