### PR TITLE
For DBFS private link we need both DFS & Blob private endpoints

### DIFF
--- a/examples/adb-with-private-links-exfiltration-protection/.terraform.lock.hcl
+++ b/examples/adb-with-private-links-exfiltration-protection/.terraform.lock.hcl
@@ -2,40 +2,18 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/databricks/databricks" {
-  version     = "1.13.0"
-  constraints = ">= 0.5.1"
+  version     = "1.20.0"
+  constraints = ">= 1.20.0"
   hashes = [
-    "h1:ga1T48DAVVP1ifvG2261xDYZ9d6zBlJc8OlkaTCHlyU=",
-    "zh:1f043e67b45749a0c58638b62b5859e367931e72f3b91c8e12151fe6222ab672",
-    "zh:32db31687e501c55412c97b998bfd853f21ef302a2b562abefc9bc2a3bbdabf2",
-    "zh:7d092ac4a1e079c482ecbe541518dff756adcf7f80cac9f7e8152ee93673bcae",
-    "zh:90a1700cbe727597c2e1fc7f27b1e41531a16dbbfad3fd7e1a31de270b4e80d5",
-    "zh:9338406075c45eb732a55927479c114759b6fb24a819e8c744317b57ec04af41",
-    "zh:b17faafdcc8e69d890037683538eb3a8d92279efd2bc1c9a4b3e1351981218f5",
-    "zh:e0c603a36facc6724ef512a946e5793fb2e021bbecc68ae7993a4f5f6bcd4d92",
-    "zh:ec5b3ab15be55e1da39c04afe02ab6b9b37f0c9135284c6df22358dc7d253316",
-    "zh:ef236b53004957e6f3ef19892ce046d90cddc260cbf54acc14ea736d7f365f61",
-    "zh:f841ea8f17d65dd8a51d6ff7728f17ccb2aaa04e43e6baa65235cc8960b77a4f",
+    "h1:5h1eyohbujc8Mcel5ggXSITyPSf5QVfqI+9mp3Llw7g=",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.49.0"
-  constraints = ">= 2.83.0"
+  version     = "3.64.0"
+  constraints = ">= 3.50.0"
   hashes = [
-    "h1:6MkC7Ft8cwFfVFY5bLBo3b0NX0U9wrNfyWzL2xCNjG8=",
-    "zh:09ca3159e6dfcfe7062f42c817806ad90e6b02fad4078bbb4d6c59f7bd612051",
-    "zh:1ad159bc759d9bbf8de8408f483f7a58a5067735004d18fd86b83272ebf72522",
-    "zh:1c98738713b5beb73f7400172c16abc5c96649c6a158bd7ae560fd46286a5633",
-    "zh:357acfccd85a21ae9c69c9b0ac2fe2452422ce88a0b0e08e27bcd1bac3c170f0",
-    "zh:4a9383f1f801cba9bc3450016e2d7cbe5c7eb14b6c3c333d2bacc88bc8a14ff2",
-    "zh:96c99b3bf016ad6a80bc2a24faeac4bd2b92824f9737cc88661396dc88e94fbb",
-    "zh:ab785827177c9d3977416614a8d351b4fce0d6029c2912a5cacc7efe9592c060",
-    "zh:cdadf38a655717942c6e3fe0508dac7094b9ea56373246b5d83afbbacbbb0be9",
-    "zh:e9f19d1173ad8ddc9248bf9558a31a0cd00651ea04c55ba9c58e52542ae39a68",
-    "zh:ef83d8077cc8fc9ad2d06125b3350337f950921bbb946aeea064c2442afa5a90",
-    "zh:f1031745dbf24760066a8d355f0922728eeb37beff130fba976eeab951eec22e",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "h1:cmleWBjFp4eK0iQICvCKxTxECx8nvl0MAfth9mLzT70=",
   ]
 }
 
@@ -43,55 +21,19 @@ provider "registry.terraform.io/hashicorp/external" {
   version = "2.3.1"
   hashes = [
     "h1:9rJggijNdRdFk//ViQPGZdK0xu9XU/9qBDijNsZJMg0=",
-    "zh:001e2886dc81fc98cf17cf34c0d53cb2dae1e869464792576e11b0f34ee92f54",
-    "zh:2eeac58dd75b1abdf91945ac4284c9ccb2bfb17fa9bdb5f5d408148ff553b3ee",
-    "zh:2fc39079ba61411a737df2908942e6970cb67ed2f4fb19090cd44ce2082903dd",
-    "zh:472a71c624952cff7aa98a7b967f6c7bb53153dbd2b8f356ceb286e6743bb4e2",
-    "zh:4cff06d31272aac8bc35e9b7faec42cf4554cbcbae1092eaab6ab7f643c215d9",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7ed16ccd2049fa089616b98c0bd57219f407958f318f3c697843e2397ddf70df",
-    "zh:842696362c92bf2645eb85c739410fd51376be6c488733efae44f4ce688da50e",
-    "zh:8985129f2eccfd7f1841ce06f3bf2bbede6352ec9e9f926fbaa6b1a05313b326",
-    "zh:a5f0602d8ec991a5411ef42f872aa90f6347e93886ce67905c53cfea37278e05",
-    "zh:bf4ab82cbe5256dcef16949973bf6aa1a98c2c73a98d6a44ee7bc40809d002b8",
-    "zh:e70770be62aa70198fa899526d671643ff99eecf265bf1a50e798fc3480bd417",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/http" {
-  version = "3.2.1"
+  version = "3.4.0"
   hashes = [
-    "h1:wKM96IefXoEIFZZEW0gzc1SV7GFZqvV8z72IMgma5/4=",
-    "zh:088b3b3128034485e11dff8da16e857d316fbefeaaf5bef24cceda34c6980641",
-    "zh:09ed1f2462ea4590b112e048c4af556f0b6eafc7cf2c75bb2ac21cd87ca59377",
-    "zh:39c6b0b4d3f0f65e783c467d3f634e2394820b8aef907fcc24493f21dcf73ca3",
-    "zh:47aab45327daecd33158a36c1a36004180a518bf1620cdd5cfc5e1fe77d5a86f",
-    "zh:4d70a990aa48116ab6f194eef393082c21cf58bece933b63575c63c1d2b66818",
-    "zh:65470c43fda950c7e9ac89417303c470146de984201fff6ef84299ea29e02d30",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:842b4dd63e438f5cd5fdfba1c09b8fdf268e8766e6690988ee24e8b25bfd9e8d",
-    "zh:a167a057f7e2d80c78d4b4057538588131fceb983d5c93b07675ad9eb1aa5790",
-    "zh:d0ba69b62b6db788cfe3cf8f7dc6e9a0eabe2927dc119d7fe3fe6573ee559e66",
-    "zh:e28d24c1d5ff24b1d1cc6f0074a1f41a6974f473f4ff7a37e55c7b6dca68308a",
-    "zh:fde8a50554960e5366fd0e1ca330a7c1d24ae6bbb2888137a5c83d83ce14fd18",
+    "h1:AaRLrzxA1t02OIwO32uLp85npqRLZSwPFgrHxb9qp0c=",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version = "3.4.3"
+  version = "3.5.1"
   hashes = [
-    "h1:tL3katm68lX+4lAncjQA9AXL4GR/VM+RPwqYf4D2X8Q=",
-    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
-    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
-    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
-    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
-    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
-    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
-    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
-    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
-    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
-    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
   ]
 }

--- a/examples/adb-with-private-links-exfiltration-protection/main.tf
+++ b/examples/adb-with-private-links-exfiltration-protection/main.tf
@@ -8,7 +8,7 @@
  * * Databricks workspace
  */
 
-module "adb-with-private-links-exfiltration-protection" {
+module "adb_with_private_links_exfiltration_protection" {
   source           = "github.com/databricks/terraform-databricks-examples/modules/adb-with-private-links-exfiltration-protection"
   hubcidr          = var.hubcidr
   spokecidr        = var.spokecidr
@@ -18,4 +18,21 @@ module "adb-with-private-links-exfiltration-protection" {
   dbfs_prefix      = var.dbfs_prefix
   workspace_prefix = var.workspace_prefix
   firewallfqdn     = var.firewallfqdn
+}
+
+output "workspace_url" {
+  value = module.adb_with_private_links_exfiltration_protection.workspace_url
+}
+
+output "workspace_azure_resource_id" {
+  value = module.adb_with_private_links_exfiltration_protection.databricks_azure_workspace_resource_id
+}
+
+output "test_vm_public_ip" {
+  value = module.adb_with_private_links_exfiltration_protection.test_vm_public_ip
+}
+
+
+output "resource_group" {
+  value = module.adb_with_private_links_exfiltration_protection.resource_group
 }

--- a/examples/adb-with-private-links-exfiltration-protection/variables.tf
+++ b/examples/adb-with-private-links-exfiltration-protection/variables.tf
@@ -1,36 +1,39 @@
 variable "hubcidr" {
-  type    = string
-  default = "10.178.0.0/20"
+  type        = string
+  default     = "10.178.0.0/20"
+  description = "CIDR for Hub VNet"
 }
 
 variable "spokecidr" {
-  type    = string
-  default = "10.179.0.0/20"
-}
-
-variable "no_public_ip" {
-  type    = bool
-  default = true
+  type        = string
+  default     = "10.179.0.0/20"
+  description = "CIDR for Spoke VNet"
 }
 
 variable "rglocation" {
-  type    = string
-  default = "southeastasia"
+  type        = string
+  default     = "southeastasia"
+  description = "Location of resource group to create"
 }
 
 variable "metastoreip" {
-  type = string
+  type        = string
+  description = "IP Address of built-in Hive Metastore in the target region"
 }
+
 variable "dbfs_prefix" {
-  type    = string
-  default = "dbfs"
+  type        = string
+  default     = "dbfs"
+  description = "Prefix for DBFS storage account name"
 }
 
 variable "workspace_prefix" {
-  type    = string
-  default = "adb"
+  type        = string
+  default     = "adb"
+  description = "Prefix to use for Workspace name"
 }
 
 variable "firewallfqdn" {
-  type = list(any)
+  type        = list(any)
+  description = "Additional list of fully qualified domain names to add to firewall rules"
 }

--- a/examples/adb-with-private-links-exfiltration-protection/versions.tf
+++ b/examples/adb-with-private-links-exfiltration-protection/versions.tf
@@ -3,12 +3,11 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = ">=0.5.1"
+      version = ">=1.20.0"
     }
-
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.83.0"
+      version = ">=3.50.0"
     }
   }
 }

--- a/modules/adb-exfiltration-protection/vnet.tf
+++ b/modules/adb-exfiltration-protection/vnet.tf
@@ -46,8 +46,8 @@ resource "azurerm_subnet" "private" {
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [cidrsubnet(local.cidr, 3, 1)]
 
-  enforce_private_link_endpoint_network_policies = true
-  enforce_private_link_service_network_policies  = true
+  private_endpoint_network_policies_enabled     = true
+  private_link_service_network_policies_enabled = true
 
   delegation {
     name = "databricks"
@@ -74,7 +74,7 @@ resource "azurerm_subnet" "plsubnet" {
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [cidrsubnet(local.cidr, 3, 2)]
-  //enforce_private_link_endpoint_network_policies = true // set to true to disable subnet policy
+  //private_endpoint_network_policies_enabled = true // set to true to disable subnet policy
 }
 
 resource "azurerm_virtual_network" "hubvnet" {

--- a/modules/adb-with-private-link-standard/endpoint_dbfs.tf
+++ b/modules/adb-with-private-link-standard/endpoint_dbfs.tf
@@ -1,19 +1,41 @@
-resource "azurerm_private_endpoint" "dp_dbfspe" {
-  name                = "dbfspvtendpoint-dp"
+// For DFS
+resource "azurerm_private_endpoint" "dp_dbfspe_dfs" {
+  name                = "dbfspvtendpoint-dp-dfs"
   location            = azurerm_resource_group.dp_rg.location
   resource_group_name = azurerm_resource_group.dp_rg.name
   subnet_id           = azurerm_subnet.dp_plsubnet.id
 
 
   private_service_connection {
-    name                           = "ple-${local.prefix}-dp-dbfs"
+    name                           = "ple-${local.prefix}-dp-dbfs-dfs"
     private_connection_resource_id = join("", [azurerm_databricks_workspace.dp_workspace.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${local.dbfsname}"])
     is_manual_connection           = false
     subresource_names              = ["dfs"]
   }
 
   private_dns_zone_group {
-    name                 = "private-dns-zone-dbfs"
-    private_dns_zone_ids = [azurerm_private_dns_zone.dnsdbfs.id]
+    name                 = "private-dns-zone-dbfs-dfs"
+    private_dns_zone_ids = [azurerm_private_dns_zone.dnsdbfs_dfs.id]
+  }
+}
+
+// for Blob
+resource "azurerm_private_endpoint" "dp_dbfspe_blob" {
+  name                = "dbfspvtendpoint-dp-blob"
+  location            = azurerm_resource_group.dp_rg.location
+  resource_group_name = azurerm_resource_group.dp_rg.name
+  subnet_id           = azurerm_subnet.dp_plsubnet.id
+
+
+  private_service_connection {
+    name                           = "ple-${local.prefix}-dp-dbfs-blob"
+    private_connection_resource_id = join("", [azurerm_databricks_workspace.dp_workspace.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${local.dbfsname}"])
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-dbfs-blob"
+    private_dns_zone_ids = [azurerm_private_dns_zone.dnsdbfs_blob.id]
   }
 }

--- a/modules/adb-with-private-link-standard/outputs.tf
+++ b/modules/adb-with-private-link-standard/outputs.tf
@@ -11,6 +11,6 @@ output "dp_workspace_url" {
 
 output "test_vm_password" {
   description = "Password to access the Test VM, use `terraform output -json test_vm_password` to get the password value"
-  value = azurerm_windows_virtual_machine.testvm.admin_password
-  sensitive = true
+  value       = azurerm_windows_virtual_machine.testvm.admin_password
+  sensitive   = true
 }

--- a/modules/adb-with-private-link-standard/private_dns_zone_dp.tf
+++ b/modules/adb-with-private-link-standard/private_dns_zone_dp.tf
@@ -10,16 +10,29 @@ resource "azurerm_private_dns_zone_virtual_network_link" "dpcpdnszonevnetlink" {
   virtual_network_id    = azurerm_virtual_network.dp_vnet.id
 }
 
-resource "azurerm_private_dns_zone" "dnsdbfs" {
+resource "azurerm_private_dns_zone" "dnsdbfs_dfs" {
   name                = "privatelink.dfs.core.windows.net"
   resource_group_name = azurerm_resource_group.dp_rg.name
 }
 
-resource "azurerm_private_dns_zone_virtual_network_link" "dbfsdnszonevnetlink" {
-  name                  = "dbfsspokevnetconnection"
+resource "azurerm_private_dns_zone" "dnsdbfs_blob" {
+  name                = "privatelink.blob.core.windows.net"
+  resource_group_name = azurerm_resource_group.dp_rg.name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "dbfsdnszonevnetlink_dfs" {
+  name                  = "dbfsspokevnetconnection-dfs"
   resource_group_name   = azurerm_resource_group.dp_rg.name
-  private_dns_zone_name = azurerm_private_dns_zone.dnsdbfs.name
+  private_dns_zone_name = azurerm_private_dns_zone.dnsdbfs_dfs.name
   virtual_network_id    = azurerm_virtual_network.dp_vnet.id
 }
+
+resource "azurerm_private_dns_zone_virtual_network_link" "dbfsdnszonevnetlink_blob" {
+  name                  = "dbfsspokevnetconnection-blob"
+  resource_group_name   = azurerm_resource_group.dp_rg.name
+  private_dns_zone_name = azurerm_private_dns_zone.dnsdbfs_blob.name
+  virtual_network_id    = azurerm_virtual_network.dp_vnet.id
+}
+
 
 

--- a/modules/adb-with-private-link-standard/vnet_dp.tf
+++ b/modules/adb-with-private-link-standard/vnet_dp.tf
@@ -74,8 +74,8 @@ resource "azurerm_subnet" "dp_private" {
   virtual_network_name = azurerm_virtual_network.dp_vnet.name
   address_prefixes     = [cidrsubnet(var.cidr_dp, 6, 1)]
 
-  enforce_private_link_endpoint_network_policies = true
-  enforce_private_link_service_network_policies  = true
+  private_endpoint_network_policies_enabled     = true
+  private_link_service_network_policies_enabled = true
 
   delegation {
     name = "databricks"
@@ -97,9 +97,9 @@ resource "azurerm_subnet_network_security_group_association" "dp_private" {
 }
 
 resource "azurerm_subnet" "dp_plsubnet" {
-  name                                           = "${local.prefix}-dp-privatelink"
-  resource_group_name                            = azurerm_resource_group.dp_rg.name
-  virtual_network_name                           = azurerm_virtual_network.dp_vnet.name
-  address_prefixes                               = [cidrsubnet(var.cidr_dp, 6, 2)]
-  enforce_private_link_endpoint_network_policies = true
+  name                                      = "${local.prefix}-dp-privatelink"
+  resource_group_name                       = azurerm_resource_group.dp_rg.name
+  virtual_network_name                      = azurerm_virtual_network.dp_vnet.name
+  address_prefixes                          = [cidrsubnet(var.cidr_dp, 6, 2)]
+  private_endpoint_network_policies_enabled = true
 }

--- a/modules/adb-with-private-link-standard/vnet_transit.tf
+++ b/modules/adb-with-private-link-standard/vnet_transit.tf
@@ -73,8 +73,8 @@ resource "azurerm_subnet" "transit_private" {
   virtual_network_name = azurerm_virtual_network.transit_vnet.name
   address_prefixes     = [cidrsubnet(var.cidr_transit, 6, 1)]
 
-  enforce_private_link_endpoint_network_policies = true
-  enforce_private_link_service_network_policies  = true
+  private_endpoint_network_policies_enabled     = true
+  private_link_service_network_policies_enabled = true
 
   delegation {
     name = "databricks"
@@ -97,9 +97,9 @@ resource "azurerm_subnet_network_security_group_association" "transit_private" {
 
 
 resource "azurerm_subnet" "transit_plsubnet" {
-  name                                           = "${local.prefix}-transit-privatelink"
-  resource_group_name                            = azurerm_resource_group.transit_rg.name
-  virtual_network_name                           = azurerm_virtual_network.transit_vnet.name
-  address_prefixes                               = [cidrsubnet(var.cidr_transit, 6, 2)]
-  enforce_private_link_endpoint_network_policies = true
+  name                                      = "${local.prefix}-transit-privatelink"
+  resource_group_name                       = azurerm_resource_group.transit_rg.name
+  virtual_network_name                      = azurerm_virtual_network.transit_vnet.name
+  address_prefixes                          = [cidrsubnet(var.cidr_transit, 6, 2)]
+  private_endpoint_network_policies_enabled = true
 }

--- a/modules/adb-with-private-links-exfiltration-protection/privateendpoint.tf
+++ b/modules/adb-with-private-links-exfiltration-protection/privateendpoint.tf
@@ -49,16 +49,16 @@ resource "azurerm_private_endpoint" "auth" {
   }
 }
 
-//dbfs pvt endpoint
-resource "azurerm_private_endpoint" "dbfspe" {
-  name                = "dbfspvtendpoint"
+//dbfs pvt endpoint - dfs
+resource "azurerm_private_endpoint" "dbfspe_dfs" {
+  name                = "dbfspvtendpoint-dfs"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   subnet_id           = azurerm_subnet.plsubnet.id //private link subnet, in databricks spoke vnet
 
 
   private_service_connection {
-    name                           = "ple-${var.workspace_prefix}-dbfs"
+    name                           = "ple-${var.workspace_prefix}-dbfs-dfs"
     private_connection_resource_id = join("", [azurerm_databricks_workspace.this.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${local.dbfsname}"])
     is_manual_connection           = false
     subresource_names              = ["dfs"]
@@ -66,17 +66,50 @@ resource "azurerm_private_endpoint" "dbfspe" {
 
   private_dns_zone_group {
     name                 = "private-dns-zone-dbfs"
-    private_dns_zone_ids = [azurerm_private_dns_zone.dnsdbfs.id]
+    private_dns_zone_ids = [azurerm_private_dns_zone.dnsdbfs_dfs.id]
   }
 }
-resource "azurerm_private_dns_zone" "dnsdbfs" {
+resource "azurerm_private_dns_zone" "dnsdbfs_dfs" {
   name                = "privatelink.dfs.core.windows.net"
   resource_group_name = azurerm_resource_group.this.name
 }
 
-resource "azurerm_private_dns_zone_virtual_network_link" "dbfsdnszonevnetlink" {
-  name                  = "dbfsspokevnetconnection"
+resource "azurerm_private_dns_zone_virtual_network_link" "dbfsdnszonevnetlink_dfs" {
+  name                  = "dbfsspokevnetconnection-dfs"
   resource_group_name   = azurerm_resource_group.this.name
-  private_dns_zone_name = azurerm_private_dns_zone.dnsdbfs.name
+  private_dns_zone_name = azurerm_private_dns_zone.dnsdbfs_dfs.name
   virtual_network_id    = azurerm_virtual_network.this.id // connect to spoke vnet
 }
+
+//dbfs pvt endpoint - blob
+resource "azurerm_private_endpoint" "dbfspe_blob" {
+  name                = "dbfspvtendpoint-blob"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  subnet_id           = azurerm_subnet.plsubnet.id //private link subnet, in databricks spoke vnet
+
+
+  private_service_connection {
+    name                           = "ple-${var.workspace_prefix}-dbfs-blob"
+    private_connection_resource_id = join("", [azurerm_databricks_workspace.this.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${local.dbfsname}"])
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-dbfs"
+    private_dns_zone_ids = [azurerm_private_dns_zone.dnsdbfs_blob.id]
+  }
+}
+resource "azurerm_private_dns_zone" "dnsdbfs_blob" {
+  name                = "privatelink.blob.core.windows.net"
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "dbfsdnszonevnetlink_blob" {
+  name                  = "dbfsspokevnetconnection-blob"
+  resource_group_name   = azurerm_resource_group.this.name
+  private_dns_zone_name = azurerm_private_dns_zone.dnsdbfs_blob.name
+  virtual_network_id    = azurerm_virtual_network.this.id // connect to spoke vnet
+}
+

--- a/modules/adb-with-private-links-exfiltration-protection/testvm.tf
+++ b/modules/adb-with-private-links-exfiltration-protection/testvm.tf
@@ -24,6 +24,7 @@ resource "azurerm_network_interface_security_group_association" "testvmnsgassoc"
 }
 
 data "http" "my_public_ip" { // add your host machine ip into nsg
+
   url = "https://ifconfig.co/json"
   request_headers = {
     Accept = "application/json"
@@ -31,7 +32,7 @@ data "http" "my_public_ip" { // add your host machine ip into nsg
 }
 
 locals {
-  ifconfig_co_json = jsondecode(data.http.my_public_ip.body)
+  ifconfig_co_json = jsondecode(data.http.my_public_ip.response_body)
 }
 
 output "my_ip_addr" {
@@ -61,13 +62,17 @@ resource "azurerm_public_ip" "testvmpublicip" {
   sku                 = "Standard"
 }
 
+output "test_vm_public_ip" {
+  value = azurerm_public_ip.testvmpublicip.ip_address
+}
+
 resource "azurerm_windows_virtual_machine" "testvm" {
   name                = "${local.prefix}-test"
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
   size                = "Standard_F4s_v2"
   admin_username      = "azureuser"
-  admin_password      = "TesTed567!!!"
+  admin_password      = var.test_vm_password
   network_interface_ids = [
     azurerm_network_interface.testvmnic.id,
   ]

--- a/modules/adb-with-private-links-exfiltration-protection/variables.tf
+++ b/modules/adb-with-private-links-exfiltration-protection/variables.tf
@@ -1,36 +1,45 @@
 variable "hubcidr" {
-  type    = string
-  default = "10.178.0.0/20"
+  type        = string
+  default     = "10.178.0.0/20"
+  description = "CIDR for Hub VNet"
 }
 
 variable "spokecidr" {
-  type    = string
-  default = "10.179.0.0/20"
-}
-
-variable "no_public_ip" {
-  type    = bool
-  default = true
+  type        = string
+  default     = "10.179.0.0/20"
+  description = "CIDR for Spoke VNet"
 }
 
 variable "rglocation" {
-  type    = string
-  default = "southeastasia"
+  type        = string
+  default     = "southeastasia"
+  description = "Location of resource group to create"
 }
 
 variable "metastoreip" {
-  type = string
+  type        = string
+  description = "IP Address of built-in Hive Metastore in the target region"
 }
+
 variable "dbfs_prefix" {
-  type    = string
-  default = "dbfs"
+  type        = string
+  default     = "dbfs"
+  description = "Prefix for DBFS storage account name"
 }
 
 variable "workspace_prefix" {
-  type    = string
-  default = "adb"
+  type        = string
+  default     = "adb"
+  description = "Prefix to use for Workspace name"
 }
 
 variable "firewallfqdn" {
-  type = list(any)
+  type        = list(any)
+  description = "Additional list of fully qualified domain names to add to firewall rules"
+}
+
+variable "test_vm_password" {
+  type        = string
+  default     = "TesTed567!!!"
+  description = "Password for Test VM"
 }

--- a/modules/adb-with-private-links-exfiltration-protection/versions.tf
+++ b/modules/adb-with-private-links-exfiltration-protection/versions.tf
@@ -3,12 +3,11 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = ">=0.5.1"
+      version = ">=1.20.0"
     }
-
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.83.0"
+      version = ">=3.50.0"
     }
   }
 }

--- a/modules/adb-with-private-links-exfiltration-protection/vnet.tf
+++ b/modules/adb-with-private-links-exfiltration-protection/vnet.tf
@@ -74,8 +74,8 @@ resource "azurerm_subnet" "private" {
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [cidrsubnet(local.cidr, 3, 1)]
 
-  enforce_private_link_endpoint_network_policies = true
-  enforce_private_link_service_network_policies  = true
+  private_endpoint_network_policies_enabled     = true
+  private_link_service_network_policies_enabled = true
 
   delegation {
     name = "databricks"
@@ -98,11 +98,11 @@ resource "azurerm_subnet_network_security_group_association" "private" {
 
 
 resource "azurerm_subnet" "plsubnet" {
-  name                                           = "${local.prefix}-privatelink"
-  resource_group_name                            = azurerm_resource_group.this.name
-  virtual_network_name                           = azurerm_virtual_network.this.name
-  address_prefixes                               = [cidrsubnet(local.cidr, 3, 2)]
-  enforce_private_link_endpoint_network_policies = true // set to true to disable subnet policy
+  name                                      = "${local.prefix}-privatelink"
+  resource_group_name                       = azurerm_resource_group.this.name
+  virtual_network_name                      = azurerm_virtual_network.this.name
+  address_prefixes                          = [cidrsubnet(local.cidr, 3, 2)]
+  private_endpoint_network_policies_enabled = true // set to true to disable subnet policy
 }
 
 

--- a/modules/adb-with-private-links-exfiltration-protection/workspace.tf
+++ b/modules/adb-with-private-links-exfiltration-protection/workspace.tf
@@ -9,7 +9,7 @@ resource "azurerm_databricks_workspace" "this" {
   customer_managed_key_enabled          = true
   //infrastructure_encryption_enabled = true
   custom_parameters {
-    no_public_ip                                         = var.no_public_ip
+    no_public_ip                                         = true
     virtual_network_id                                   = azurerm_virtual_network.this.id
     private_subnet_name                                  = azurerm_subnet.private.name
     public_subnet_name                                   = azurerm_subnet.public.name


### PR DESCRIPTION
tested manually for `adb-with-private-links-exfiltration-protection`

Also:
* resolved some warnings about deprecated fields
* added outputs to `adb-with-private-links-exfiltration-protection` example
* make Test VM password configurable in `adb-with-private-links-exfiltration-protection` module
* Added descriptions for variables in `adb-with-private-links-exfiltration-protection` module

this fixes #86