### PR TITLE
Rework adb-exfiltration-protection module based on the practical usage

### DIFF
--- a/examples/adb-exfiltration-protection/main.tf
+++ b/examples/adb-exfiltration-protection/main.tf
@@ -1,23 +1,27 @@
 /**
- * Azure Databricks workspace in custom VNet
+ * Azure Databricks workspace in custom VNet with traffic routed via firewall in the Hub VNet
  *
  * Module creates:
  * * Resource group with random prefix
  * * Tags, including `Owner`, which is taken from `az account show --query user`
- * * VNet with public and private subnet
+ * * VNet with public and private subnet for Databricks
+ * * VNet with subnet for deployment of Azure Firewall
+ * * Azure Firewall with access enabled to Databricks-related resources
  * * Databricks workspace
  */
 
 module "adb-exfiltration-protection" {
-  source       = "github.com/databricks/terraform-databricks-examples/modules/adb-exfiltration-protection"
-  hubcidr          = var.hubcidr
-  spokecidr        = var.spokecidr
-  no_public_ip     = var.no_public_ip
-  rglocation       = var.rglocation
-  metastoreip      = var.metastoreip
-  sccip            = var.sccip
-  webappip         = var.webappip
-  dbfs_prefix      = var.dbfs_prefix
-  workspace_prefix = var.workspace_prefix
-  firewallfqdn     = var.firewallfqdn
+  source            = "../../modules/adb-exfiltration-protection"
+  hubcidr           = var.hubcidr
+  spokecidr         = var.spokecidr
+  no_public_ip      = var.no_public_ip
+  rglocation        = var.rglocation
+  metastore         = var.metastore
+  scc_relay         = var.scc_relay
+  webapp_ips        = var.webapp_ips
+  extended_infra_ip = var.extended_infra_ip
+  dbfs_prefix       = var.dbfs_prefix
+  workspace_prefix  = var.workspace_prefix
+  firewallfqdn      = var.firewallfqdn
+  eventhubs         = var.eventhubs
 }

--- a/examples/adb-exfiltration-protection/terraform.tfvars
+++ b/examples/adb-exfiltration-protection/terraform.tfvars
@@ -1,16 +1,57 @@
-hubcidr          = "10.178.0.0/20"
-spokecidr        = "10.179.0.0/20"
-no_public_ip     = true
-rglocation       = "southeastasia"
-metastoreip      = "40.78.233.2"
-sccip            = "52.230.27.216/32" // get scc ip from nslookup 
-webappip         = "52.187.145.107/32"
-dbfs_prefix      = "dbfs"
-workspace_prefix = "adb"
-firewallfqdn = [                                                      // dbfs rule will be added - depends on dbfs storage name
-  "dbartifactsprodseap.blob.core.windows.net",                        //databricks artifacts
-  "dbartifactsprodeap.blob.core.windows.net",                         //databricks artifacts secondary
-  "dblogprodseasia.blob.core.windows.net",                            //log blob
-  "prod-southeastasia-observabilityeventhubs.servicebus.windows.net", //eventhub
-  "cdnjs.com",                                                        //ganglia
+hubcidr      = "10.178.0.0/20"
+spokecidr    = "10.179.0.0/20"
+no_public_ip = true
+rglocation   = "westeurope"
+metastore = ["consolidated-westeurope-prod-metastore.mysql.database.azure.com",
+  "consolidated-westeurope-prod-metastore-addl-1.mysql.database.azure.com",
+  "consolidated-westeurope-prod-metastore-addl-2.mysql.database.azure.com",
+  "consolidated-westeurope-prod-metastore-addl-3.mysql.database.azure.com",
+  "consolidated-westeuropec2-prod-metastore-0.mysql.database.azure.com",
+  "consolidated-westeuropec2-prod-metastore-1.mysql.database.azure.com",
+  "consolidated-westeuropec2-prod-metastore-2.mysql.database.azure.com",
+  "consolidated-westeuropec2-prod-metastore-3.mysql.database.azure.com",
 ]
+// get from https://learn.microsoft.com/en-us/azure/databricks/resources/supported-regions#--metastore-artifact-blob-storage-system-tables-blob-storage-log-blob-storage-and-event-hub-endpoint-ip-addresses
+scc_relay  = ["tunnel.westeurope.azuredatabricks.net", "tunnel.westeuropec2.azuredatabricks.net"]
+webapp_ips = ["52.230.27.216/32", "40.74.30.80/32"]
+eventhubs = ["prod-westeurope-observabilityeventhubs.servicebus.windows.net",
+  "prod-westeuc2-observabilityeventhubs.servicebus.windows.net",
+]
+extended_infra_ip = "20.73.215.48/28"
+dbfs_prefix       = "dbfs"
+workspace_prefix  = "adb"
+firewallfqdn = [                                 // dbfs rule will be added - depends on dbfs storage name
+  "dbartifactsprodwesteu.blob.core.windows.net", //databricks artifacts
+  "arprodwesteua1.blob.core.windows.net",
+  "arprodwesteua2.blob.core.windows.net",
+  "arprodwesteua3.blob.core.windows.net",
+  "arprodwesteua4.blob.core.windows.net",
+  "arprodwesteua5.blob.core.windows.net",
+  "arprodwesteua6.blob.core.windows.net",
+  "arprodwesteua7.blob.core.windows.net",
+  "arprodwesteua8.blob.core.windows.net",
+  "arprodwesteua9.blob.core.windows.net",
+  "arprodwesteua10.blob.core.windows.net",
+  "arprodwesteua11.blob.core.windows.net",
+  "arprodwesteua12.blob.core.windows.net",
+  "arprodwesteua13.blob.core.windows.net",
+  "arprodwesteua14.blob.core.windows.net",
+  "arprodwesteua15.blob.core.windows.net",
+  "arprodwesteua16.blob.core.windows.net",
+  "arprodwesteua17.blob.core.windows.net",
+  "arprodwesteua18.blob.core.windows.net",
+  "arprodwesteua19.blob.core.windows.net",
+  "arprodwesteua20.blob.core.windows.net",
+  "arprodwesteua21.blob.core.windows.net",
+  "arprodwesteua22.blob.core.windows.net",
+  "arprodwesteua23.blob.core.windows.net",
+  "arprodwesteua24.blob.core.windows.net",
+  "dbartifactsprodnortheu.blob.core.windows.net", //databricks artifacts secondary
+  "ucstprdwesteu.blob.core.windows.net",          // system tables storage
+  "dblogprodwesteurope.blob.core.windows.net",    //log blob
+  "cdnjs.com",                                    //ganglia
+  // Azure monitor
+  "global.handler.control.monitor.azure.com",
+  "westeurope.handler.control.monitor.azure.com",
+]
+

--- a/examples/adb-exfiltration-protection/variables.tf
+++ b/examples/adb-exfiltration-protection/variables.tf
@@ -1,45 +1,64 @@
 variable "hubcidr" {
+  description = "IP range for creaiton of the Spoke VNet"
   type    = string
   default = "10.178.0.0/20"
 }
 
 variable "spokecidr" {
+  description = "IP range for creaiton of the Hub VNet"
   type    = string
   default = "10.179.0.0/20"
 }
 
 variable "no_public_ip" {
+  description = "If workspace should be created with No-Public-IP"
   type    = bool
   default = true
 }
 
 variable "rglocation" {
+  description = "Location of resource group"
   type    = string
-  default = "southeastasia"
 }
 
-variable "metastoreip" {
+variable "metastore" {
+  description = "List of FQDNs for Azure Databricks Metastore databases"
+  type = list(string)
+}
+
+variable "scc_relay" {
+  description = "List of FQDNs for Azure Databricks Secure Cluster Connectivity relay"
+  type = list(string)
+}
+
+variable "webapp_ips" {
+  description = "List of IP ranges for Azure Databricks Webapp"
+  type = list(string)
+}
+
+variable "extended_infra_ip" {
+  description = "IP range for Azure Databricks extended infrastructure"
   type = string
 }
 
-variable "sccip" {
-  type = string
-}
-
-variable "webappip" {
-  type = string
+variable "eventhubs" {
+  description = "List of FQDNs for Azure Databricks EventHubs traffic"
+  type = list(string)
 }
 
 variable "dbfs_prefix" {
+  description = "Prefix for DBFS storage account name"
   type    = string
   default = "dbfs"
 }
 
 variable "workspace_prefix" {
+  description = "Prefix for workspace name"
   type    = string
   default = "adb"
 }
 
 variable "firewallfqdn" {
   type = list(any)
+  description = "List of domains names to put into application rules for handling of HTTPS traffic (Databricks storage accounts, etc.)"
 }

--- a/examples/adb-exfiltration-protection/versions.tf
+++ b/examples/adb-exfiltration-protection/versions.tf
@@ -3,12 +3,17 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = ">=0.5.1"
+      version = ">=1.20.0"
     }
-
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">=2.83.0"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    dns = {
+      source = "hashicorp/dns"
     }
   }
 }

--- a/modules/adb-exfiltration-protection/firewall.tf
+++ b/modules/adb-exfiltration-protection/firewall.tf
@@ -4,6 +4,7 @@ resource "azurerm_public_ip" "fwpublicip" {
   resource_group_name = azurerm_resource_group.this.name
   allocation_method   = "Static"
   sku                 = "Standard"
+  tags                = local.tags
 }
 
 resource "azurerm_firewall" "hubfw" {
@@ -12,12 +13,34 @@ resource "azurerm_firewall" "hubfw" {
   resource_group_name = azurerm_resource_group.this.name
   sku_name            = "AZFW_VNet"
   sku_tier            = "Standard"
+  tags                = local.tags
 
   ip_configuration {
     name                 = "configuration"
     subnet_id            = azurerm_subnet.hubfw.id
     public_ip_address_id = azurerm_public_ip.fwpublicip.id
   }
+}
+
+locals {
+  metastore_ips = toset(flatten([for k, v in data.dns_a_record_set.metastore : v.addrs]))
+  eventhubs_ips = toset(flatten([for k, v in data.dns_a_record_set.eventhubs : v.addrs]))
+  scc_relay_ips = toset(flatten([for k, v in data.dns_a_record_set.scc_relay : v.addrs]))
+}
+
+data "dns_a_record_set" "metastore" {
+  for_each = toset(var.metastore)
+  host     = each.value
+}
+
+data "dns_a_record_set" "eventhubs" {
+  for_each = toset(var.eventhubs)
+  host     = each.value
+}
+
+data "dns_a_record_set" "scc_relay" {
+  for_each = toset(var.scc_relay)
+  host     = each.value
 }
 
 resource "azurerm_firewall_network_rule_collection" "adbfnetwork" {
@@ -28,27 +51,6 @@ resource "azurerm_firewall_network_rule_collection" "adbfnetwork" {
   action              = "Allow"
 
   rule {
-    name = "databricks-metastore"
-
-    source_addresses = [
-      join(", ", azurerm_subnet.public.address_prefixes),
-      join(", ", azurerm_subnet.private.address_prefixes),
-    ]
-
-    destination_ports = [
-      "3306",
-    ]
-
-    destination_addresses = [
-      var.metastoreip,
-    ]
-
-    protocols = [
-      "TCP",
-    ]
-  }
-
-  rule {
     name = "databricks-webapp"
 
     source_addresses = [
@@ -57,17 +59,61 @@ resource "azurerm_firewall_network_rule_collection" "adbfnetwork" {
     ]
 
     destination_ports = [
-      "443",
+      "443", "8443", "8444",
     ]
 
-    destination_addresses = [
-      var.webappip,
-    ]
+    destination_addresses = var.webapp_ips
 
     protocols = [
       "TCP",
     ]
   }
+
+  rule {
+    name = "databricks-extended_infra"
+
+    source_addresses = [
+      join(", ", azurerm_subnet.public.address_prefixes),
+      join(", ", azurerm_subnet.private.address_prefixes),
+    ]
+
+    destination_addresses = [var.extended_infra_ip]
+    destination_ports     = ["*"]
+    protocols = [
+      "TCP",
+    ]
+  }
+
+  rule {
+    name = "databricks-metastore"
+
+    source_addresses = [
+      join(", ", azurerm_subnet.public.address_prefixes),
+      join(", ", azurerm_subnet.private.address_prefixes),
+    ]
+
+    destination_addresses = local.metastore_ips
+    destination_ports     = ["3306"]
+    protocols = [
+      "TCP",
+    ]
+  }
+
+  rule {
+    name = "databricks-eventhubs"
+
+    source_addresses = [
+      join(", ", azurerm_subnet.public.address_prefixes),
+      join(", ", azurerm_subnet.private.address_prefixes),
+    ]
+
+    destination_addresses = local.eventhubs_ips
+    destination_ports     = ["9093"]
+    protocols = [
+      "TCP",
+    ]
+  }
+
 }
 
 
@@ -102,7 +148,7 @@ resource "azurerm_firewall_application_rule_collection" "adbfqdn" {
       join(", ", azurerm_subnet.private.address_prefixes),
     ]
 
-    target_fqdns = ["${local.dbfsname}.dfs.core.windows.net"]
+    target_fqdns = ["${local.dbfsname}.dfs.core.windows.net", "${local.dbfsname}.blob.core.windows.net"]
 
     protocol {
       port = "443"
@@ -125,6 +171,25 @@ resource "azurerm_firewall_application_rule_collection" "adbfqdn" {
       type = "Https"
     }
   }
+
+  dynamic "rule" {
+    for_each = var.bypass_scc_relay ? [] : [1]
+    content {
+      name = "databricks-scc-relay"
+
+      source_addresses = [
+        join(", ", azurerm_subnet.public.address_prefixes),
+        join(", ", azurerm_subnet.private.address_prefixes),
+      ]
+
+      target_fqdns = var.scc_relay
+
+      protocol {
+        port = "443"
+        type = "Https"
+      }
+    }
+  }
 }
 
 resource "azurerm_route_table" "adbroute" {
@@ -132,6 +197,7 @@ resource "azurerm_route_table" "adbroute" {
   name                = "spoke-routetable"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
+  tags                = local.tags
 
   route {
     name                   = "to-firewall"
@@ -140,10 +206,13 @@ resource "azurerm_route_table" "adbroute" {
     next_hop_in_ip_address = azurerm_firewall.hubfw.ip_configuration.0.private_ip_address // extract single item
   }
 
-  route {
-    name           = "to-scc"
-    address_prefix = var.sccip
-    next_hop_type  = "Internet" // since scc is azure service IP, traffic will remain in azure backbone, not Internet
+  dynamic "route" {
+    for_each = var.bypass_scc_relay ? local.scc_relay_ips : []
+    content {
+      name           = "to-scc-${route.value}"
+      address_prefix = "${route.value}/32"
+      next_hop_type  = "Internet" // since scc is azure service IP, traffic will remain in azure backbone, not Internet
+    }
   }
 
 }

--- a/modules/adb-exfiltration-protection/main.tf
+++ b/modules/adb-exfiltration-protection/main.tf
@@ -11,9 +11,6 @@ provider "azurerm" {
   features {}
 }
 
-provider "random" {
-}
-
 resource "random_string" "naming" {
   special = false
   upper   = false
@@ -35,11 +32,11 @@ locals {
   dbfsname = join("", [var.dbfs_prefix, "${random_string.naming.result}"]) // dbfs name must not have special chars
 
   // tags that are propagated down to all resources
-  tags = {
+  tags = merge({
     Environment = "Testing"
     Owner       = lookup(data.external.me.result, "name")
     Epoch       = random_string.naming.result
-  }
+  }, var.tags)
 }
 
 resource "azurerm_resource_group" "this" {

--- a/modules/adb-exfiltration-protection/variables.tf
+++ b/modules/adb-exfiltration-protection/variables.tf
@@ -1,45 +1,75 @@
 variable "hubcidr" {
+  description = "IP range for creaiton of the Spoke VNet"
   type    = string
   default = "10.178.0.0/20"
 }
 
 variable "spokecidr" {
+  description = "IP range for creaiton of the Hub VNet"
   type    = string
   default = "10.179.0.0/20"
 }
 
 variable "no_public_ip" {
+  description = "If workspace should be created with No-Public-IP"
   type    = bool
   default = true
 }
 
 variable "rglocation" {
+  description = "Location of resource group"
   type    = string
-  default = "southeastasia"
 }
 
-variable "metastoreip" {
+variable "metastore" {
+  description = "List of FQDNs for Azure Databricks Metastore databases"
+  type = list(string)
+}
+
+variable "scc_relay" {
+  description = "List of FQDNs for Azure Databricks Secure Cluster Connectivity relay"
+  type = list(string)
+}
+
+variable "webapp_ips" {
+  description = "List of IP ranges for Azure Databricks Webapp"
+  type = list(string)
+}
+
+variable "extended_infra_ip" {
+  description = "IP range for Azure Databricks extended infrastructure"
   type = string
 }
 
-variable "sccip" {
-  type = string
-}
-
-variable "webappip" {
-  type = string
+variable "eventhubs" {
+  description = "List of FQDNs for Azure Databricks EventHubs traffic"
+  type = list(string)
 }
 
 variable "dbfs_prefix" {
+  description = "Prefix for DBFS storage account name"
   type    = string
   default = "dbfs"
 }
 
 variable "workspace_prefix" {
+  description = "Prefix for workspace name"
   type    = string
   default = "adb"
 }
 
 variable "firewallfqdn" {
   type = list(any)
+  description = "List of domains names to put into application rules for handling of HTTPS traffic (Databricks storage accounts, etc.)"
+}
+
+variable "tags" {
+  description = "Additional tags to add to created resources"
+  default     = {}
+}
+
+variable "bypass_scc_relay" {
+  description = "If we should bypass firewall for Secure Cluster Connectivity traffic or not"
+  type        = bool
+  default     = true
 }

--- a/modules/adb-exfiltration-protection/versions.tf
+++ b/modules/adb-exfiltration-protection/versions.tf
@@ -3,12 +3,17 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = ">=0.5.1"
+      version = ">=1.20.0"
     }
-
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">=2.83.0"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    dns = {
+      source = "hashicorp/dns"
     }
   }
 }


### PR DESCRIPTION
Changes include:

- Added `dns` provider to resolve FQDNs into IP Addresses to simplify configuration
- SCC Relay & Metastore are now lists of FQDNs instead of IP addresses - that's required for bigger regions like, West Europe
- Added variable for extended infrastructure IP range
- Moved ADB EventHubs into a separate variable and made it a list of FQDNs (also required for bigger regions. Moved handling of EventHubs traffic to the network rules because we need to handle port 9093
- Added a variable to control if we should skip routing of SCC traffic via firewall or not
- Added a possibility to add/override tags
- Bumped Databricks provider version

`adb-with-private-links-exfiltration-protection` will be changed as well after this PR is merged.