### PR TITLE
Fix for s3 bucket acl & added custom prefix

### DIFF
--- a/modules/aws-exfiltration-protection/s3.tf
+++ b/modules/aws-exfiltration-protection/s3.tf
@@ -13,6 +13,13 @@ resource "aws_s3_bucket_versioning" "versioning" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "state" {
+  bucket = aws_s3_bucket.root_storage_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "acl" {
   bucket = aws_s3_bucket.root_storage_bucket.id
   acl    = "private"

--- a/modules/aws-workspace-basic/main.tf
+++ b/modules/aws-workspace-basic/main.tf
@@ -5,5 +5,5 @@ resource "random_string" "naming" {
 }
 
 locals {
-  prefix = "demo${random_string.naming.result}"
+  prefix = var.prefix != "" ? var.prefix : "demo${random_string.naming.result}"
 }

--- a/modules/aws-workspace-basic/s3.tf
+++ b/modules/aws-workspace-basic/s3.tf
@@ -13,6 +13,13 @@ resource "aws_s3_bucket_versioning" "versioning" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "state" {
+  bucket = aws_s3_bucket.root_storage_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "acl" {
   bucket = aws_s3_bucket.root_storage_bucket.id
   acl    = "private"

--- a/modules/aws-workspace-basic/variables.tf
+++ b/modules/aws-workspace-basic/variables.tf
@@ -11,3 +11,8 @@ variable "cidr_block" {
 variable "region" {
   default = "eu-west-1"
 }
+
+variable "prefix" {
+  default = null
+  description = "Default value is demo"
+}

--- a/modules/aws-workspace-with-firewall/s3.tf
+++ b/modules/aws-workspace-with-firewall/s3.tf
@@ -30,6 +30,13 @@ resource "aws_s3_bucket_policy" "root_bucket_policy" {
   depends_on = [aws_s3_bucket_public_access_block.root_storage_bucket]
 }
 
+resource "aws_s3_bucket_ownership_controls" "state" {
+  bucket = aws_s3_bucket.root_storage_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "root_storage_bucket" {
   bucket     = aws_s3_bucket.root_storage_bucket.id
   acl        = "private"


### PR DESCRIPTION
The aws-workspace-basic module failed when trying to run because of a change in the policy for default values on s3 bucket (blog from aws [here](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/))

Also for that module the result workspace always had the same name, I add the ability to optionally add a prefix that would end being the workspace name.