### PR TITLE
change readme title: Azure to AWS

### DIFF
--- a/examples/aws-exfiltration-protection/README.md
+++ b/examples/aws-exfiltration-protection/README.md
@@ -1,4 +1,4 @@
-# Provisioning Azure Databricks workspace with a Hub & Spoke firewall for data exfiltration protection
+# Provisioning AWS Databricks workspace with a Hub & Spoke firewall for data exfiltration protection
 
 This example is using the [aws-exfiltration-protection](../../modules/aws-exfiltration-protection) module.
 


### PR DESCRIPTION
just fixing text title in readme, confusing for customers who click on AWS Data Exfiltration but see that the title is Azure Data Exfiltration