### PR TITLE
fix dependecy and add workspace_id as a new output

### DIFF
--- a/modules/aws-exfiltration-protection/s3.tf
+++ b/modules/aws-exfiltration-protection/s3.tf
@@ -21,8 +21,9 @@ resource "aws_s3_bucket_ownership_controls" "state" {
 }
 
 resource "aws_s3_bucket_acl" "acl" {
-  bucket = aws_s3_bucket.root_storage_bucket.id
-  acl    = "private"
+  bucket     = aws_s3_bucket.root_storage_bucket.id
+  acl        = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.state]
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "root_storage_bucket" {

--- a/modules/aws-workspace-basic/outputs.tf
+++ b/modules/aws-workspace-basic/outputs.tf
@@ -6,3 +6,7 @@ output "databricks_token" {
   value     = databricks_mws_workspaces.this.token[0].token_value
   sensitive = true
 }
+
+output "workspace_id" {
+  value = databricks_mws_workspaces.this.workspace_id
+}

--- a/modules/aws-workspace-basic/s3.tf
+++ b/modules/aws-workspace-basic/s3.tf
@@ -21,8 +21,9 @@ resource "aws_s3_bucket_ownership_controls" "state" {
 }
 
 resource "aws_s3_bucket_acl" "acl" {
-  bucket = aws_s3_bucket.root_storage_bucket.id
-  acl    = "private"
+  bucket     = aws_s3_bucket.root_storage_bucket.id
+  acl        = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.state]
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "root_storage_bucket" {

--- a/modules/aws-workspace-with-firewall/s3.tf
+++ b/modules/aws-workspace-with-firewall/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "root_storage_bucket" {
-  bucket = "${local.prefix}-rootbucket"
+  bucket        = "${local.prefix}-rootbucket"
   force_destroy = true
   tags = merge(var.tags, {
     Name = "${local.prefix}-rootbucket"
@@ -40,10 +40,11 @@ resource "aws_s3_bucket_ownership_controls" "state" {
 resource "aws_s3_bucket_acl" "root_storage_bucket" {
   bucket     = aws_s3_bucket.root_storage_bucket.id
   acl        = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.state]
 }
 
 resource "aws_s3_bucket_versioning" "versioning_example" {
-  bucket     = aws_s3_bucket.root_storage_bucket.id
+  bucket = aws_s3_bucket.root_storage_bucket.id
   versioning_configuration {
     status = "Disabled"
   }


### PR DESCRIPTION
Added the depends_on, because sometimes it doesn't setup the owner correctly so we're not able to do acl to the bucket.

Also, added workspace_id as an output, so the idea of using this module can be linked to another modules or resources (e.g attach a metastore after creating the workspace)