### PR TITLE
Adding Workspace Name as a Variable in aws-databricks-workspace

### DIFF
--- a/examples/aws-workspace-uc-simple/main.tf
+++ b/examples/aws-workspace-uc-simple/main.tf
@@ -26,6 +26,7 @@ module "databricks_workspace" {
   root_storage_bucket    = module.aws_base.root_bucket
   cross_account_role_arn = module.aws_base.cross_account_role_arn
   tags                   = local.tags
+  
   depends_on = [
     module.aws_base
   ]

--- a/examples/aws-workspace-uc-simple/main.tf
+++ b/examples/aws-workspace-uc-simple/main.tf
@@ -26,7 +26,6 @@ module "databricks_workspace" {
   root_storage_bucket    = module.aws_base.root_bucket
   cross_account_role_arn = module.aws_base.cross_account_role_arn
   tags                   = local.tags
- 
   depends_on = [
     module.aws_base
   ]

--- a/examples/aws-workspace-uc-simple/main.tf
+++ b/examples/aws-workspace-uc-simple/main.tf
@@ -17,6 +17,7 @@ module "databricks_workspace" {
   }
   source                 = "../../modules/aws-databricks-workspace"
   prefix                 = local.prefix
+  workspace_name         = var.workspace_name
   region                 = var.region
   databricks_account_id  = var.databricks_account_id
   security_group_ids     = module.aws_base.security_group_ids
@@ -25,7 +26,7 @@ module "databricks_workspace" {
   root_storage_bucket    = module.aws_base.root_bucket
   cross_account_role_arn = module.aws_base.cross_account_role_arn
   tags                   = local.tags
-
+ 
   depends_on = [
     module.aws_base
   ]

--- a/examples/aws-workspace-uc-simple/terraform.tfvars
+++ b/examples/aws-workspace-uc-simple/terraform.tfvars
@@ -8,6 +8,7 @@ unity_admin_group           = "unity-admin-group"                            // 
 databricks_account_id       = "YOUR_DATABRICKS_ACCOUNT_ID"                   // Databricks Account ID
 databricks_client_id        = "YOUR_SERVICE_PRINCIPAL_CLIENT_ID"             // Databricks Service Principal Client ID
 databricks_client_secret    = "YOUR_SERVICE_PRINCIPAL_CLIENT_SECRET"         // Databricks Service Principal Client Secret
+workspace_name              = "YOUR_DATABRICKS_WORKSPACE_NAME"               // Databricks Workspace Name - IF NOT PROVIDED or EMPTY it will defauly to a random "demo-<number>" prefix
 tags = {
   Environment = "Demo-with-terraform"
 }

--- a/examples/aws-workspace-uc-simple/variables.tf
+++ b/examples/aws-workspace-uc-simple/variables.tf
@@ -5,6 +5,11 @@ variable "tags" {
   description = "(Optional) List of tags to be propagated accross all assets in this demo"
 }
 
+variable "workspace_name" {
+  type        = string
+  description = "(Required) Databricks workspace name to be used for deployment"
+}
+
 variable "cidr_block" {
   type        = string
   description = "(Required) CIDR block to be used to create the Databricks VPC"

--- a/modules/aws-databricks-workspace/main.tf
+++ b/modules/aws-databricks-workspace/main.tf
@@ -21,7 +21,7 @@ resource "databricks_mws_storage_configurations" "this" {
 resource "databricks_mws_workspaces" "this" {
   account_id     = var.databricks_account_id
   aws_region     = var.region
-  workspace_name = var.prefix
+  workspace_name = coalesce(var.workspace_name,var.prefix)
 
   credentials_id           = databricks_mws_credentials.this.credentials_id
   storage_configuration_id = databricks_mws_storage_configurations.this.storage_configuration_id

--- a/modules/aws-databricks-workspace/variables.tf
+++ b/modules/aws-databricks-workspace/variables.tf
@@ -5,6 +5,11 @@ variable "tags" {
   description = "(Optional) List of tags to be propagated accross all assets in this demo"
 }
 
+variable "workspace_name" {
+  type        = string
+  description = "(Optional) Workspace Name for this module - if none are provided, the prefix will be used to name the workspace via coalesce()"
+}
+
 variable "prefix" {
   type        = string
   description = "(Optional) Prefix to name the resources created by this module"

--- a/modules/aws-databricks-workspace/variables.tf
+++ b/modules/aws-databricks-workspace/variables.tf
@@ -7,6 +7,7 @@ variable "tags" {
 
 variable "workspace_name" {
   type        = string
+  default     = ""
   description = "(Optional) Workspace Name for this module - if none are provided, the prefix will be used to name the workspace via coalesce()"
 }
 


### PR DESCRIPTION
Adding the variable `workspace_name` to `modules/aws-databricks-workspace` and adding a `coalesce()` behavior to use the prefix if not specified.  (examples that use this seem to always generate a prefix as a local var) 

Then, having the example `aws-workspace-uc-simple` leverage this workspace_name as a specified input variable