### PR TITLE
Fix wrong DNS zone link in the `adb-with-private-link-standard` module

### DIFF
--- a/modules/adb-with-private-link-standard/endpoint_webauth.tf
+++ b/modules/adb-with-private-link-standard/endpoint_webauth.tf
@@ -13,7 +13,7 @@ resource "azurerm_private_endpoint" "transit_auth" {
 
   private_dns_zone_group {
     name                 = "private-dns-zone-auth"
-    private_dns_zone_ids = [azurerm_private_dns_zone.dnsdpcp.id]
+    private_dns_zone_ids = [azurerm_private_dns_zone.dns_auth_front.id]
   }
 }
 


### PR DESCRIPTION
The web auth private endpoint was linked to the wrong private DNS zone