### PR TITLE
Make creation of Azure resource group for Databricks workspace optional

### DIFF
--- a/modules/adb-lakehouse/azure_data_factory.tf
+++ b/modules/adb-lakehouse/azure_data_factory.tf
@@ -2,7 +2,7 @@ resource "azurerm_data_factory" "adf" {
   count = var.data_factory_name != "" ? 1 : 0
 
   name                = var.data_factory_name
-  location            = var.location
-  resource_group_name = azurerm_resource_group.this.name
+  location            = local.rg_location
+  resource_group_name = local.rg_name
   tags                = var.tags
 }

--- a/modules/adb-lakehouse/key_vault.tf
+++ b/modules/adb-lakehouse/key_vault.tf
@@ -1,8 +1,8 @@
 resource "azurerm_key_vault" "example" {
   count                       = var.key_vault_name != "" ? 1 : 0
   name                        = var.key_vault_name
-  location                    = var.location
-  resource_group_name         = azurerm_resource_group.this.name
+  location                    = local.rg_location
+  resource_group_name         = local.rg_name
   enabled_for_disk_encryption = true
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   soft_delete_retention_days  = 7

--- a/modules/adb-lakehouse/main.tf
+++ b/modules/adb-lakehouse/main.tf
@@ -1,7 +1,19 @@
 resource "azurerm_resource_group" "this" {
+  count    = var.create_resource_group ? 1 : 0
   name     = var.spoke_resource_group_name
   location = var.location
   tags     = var.tags
+}
+
+data "azurerm_resource_group" "this" {
+  count = var.create_resource_group ? 0 : 1
+  name  = var.spoke_resource_group_name
+}
+
+locals {
+  rg_name     = var.create_resource_group ? azurerm_resource_group.this[0].name : data.azurerm_resource_group.this[0].name
+  rg_id       = var.create_resource_group ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
+  rg_location = var.create_resource_group ? azurerm_resource_group.this[0].location : data.azurerm_resource_group.this[0].location
 }
 
 data "azurerm_client_config" "current" {

--- a/modules/adb-lakehouse/network.tf
+++ b/modules/adb-lakehouse/network.tf
@@ -1,22 +1,22 @@
 resource "azurerm_virtual_network" "this" {
   name                = "VNET-${var.project_name}-${var.environment_name}"
-  location            = var.location
-  resource_group_name = azurerm_resource_group.this.name
+  location            = local.rg_location
+  resource_group_name = local.rg_name
   address_space       = [var.spoke_vnet_address_space]
   tags                = var.tags
 }
 
 resource "azurerm_network_security_group" "this" {
   name                = "databricks-nsg-${var.project_name}-${var.environment_name}"
-  location            = azurerm_resource_group.this.location
-  resource_group_name = azurerm_resource_group.this.name
+  location            = local.rg_location
+  resource_group_name = local.rg_name
   tags                = var.tags
 }
 
 
 resource "azurerm_route_table" "this" {
   name                = "route-table-${var.project_name}-${var.environment_name}"
-  location            = azurerm_resource_group.this.location
-  resource_group_name = azurerm_resource_group.this.name
+  location            = local.rg_location
+  resource_group_name = local.rg_name
   tags                = var.tags
 }

--- a/modules/adb-lakehouse/outputs.tf
+++ b/modules/adb-lakehouse/outputs.tf
@@ -1,11 +1,11 @@
 output "rg_name" {
-  value       = azurerm_resource_group.this.name
-  description = "Name of the new resource group"
+  value       = local.rg_name
+  description = "Name of the resource group"
 }
 
 output "rg_id" {
-  value       = azurerm_resource_group.this.id
-  description = "ID of the new resource group"
+  value       = local.rg_id
+  description = "ID of the resource group"
 }
 
 output "vnet_id" {

--- a/modules/adb-lakehouse/variables.tf
+++ b/modules/adb-lakehouse/variables.tf
@@ -8,6 +8,12 @@ variable "spoke_resource_group_name" {
   description = "(Required) The name of the Resource Group to create"
 }
 
+variable "create_resource_group" {
+  type        = bool
+  description = "(Optional) Creates resource group if set to true (default)"
+  default     = true
+}
+
 variable "managed_resource_group_name" {
   type        = string
   description = "(Optional) The name of the resource group where Azure should place the managed Databricks resources"


### PR DESCRIPTION
Very often you need to deploy ADB workspace into existing resource group, but current `adb-lakehouse` module always creates a new resource group.  This PR allows to specify existing resource group name, while keeping compatibility with the previous version by creating it by default (could be disabled with the new variable).