### PR TITLE
Use consistent provider requirements across all modules and examples

### DIFF
--- a/examples/adb-private-links/versions.tf
+++ b/examples/adb-private-links/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = ">=0.5.1"
+      version = ">=1.13.0"
     }
 
     azurerm = {

--- a/examples/adb-splunk/versions.tf
+++ b/examples/adb-splunk/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = ">=0.5.1"
+      version = ">=1.13.0"
     }
 
     azurerm = {

--- a/examples/adb-vnet-injection/modules/autoscaling_cluster/main.tf
+++ b/examples/adb-vnet-injection/modules/autoscaling_cluster/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     databricks = {
       source  = "databricks/databricks"
-      version = ">=0.5.1"
+      version = ">=1.13.0"
     }
   }
 }

--- a/examples/aws-workspace-basic/versions.tf
+++ b/examples/aws-workspace-basic/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.38.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/examples/aws-workspace-basic/versions.tf
+++ b/examples/aws-workspace-basic/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.58.0"
+      version = ">=5.38.0"
     }
   }
 }

--- a/examples/aws-workspace-uc-simple/versions.tf
+++ b/examples/aws-workspace-uc-simple/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "=4.57.0"
+      version = ">=5.38.0"
     }
 
     random = {

--- a/examples/aws-workspace-uc-simple/versions.tf
+++ b/examples/aws-workspace-uc-simple/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.38.0"
+      version = "~> 5.0"
     }
 
     random = {

--- a/examples/aws-workspace-with-firewall/versions.tf
+++ b/examples/aws-workspace-with-firewall/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.38.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/examples/aws-workspace-with-firewall/versions.tf
+++ b/examples/aws-workspace-with-firewall/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.58.0"
+      version = ">=5.38.0"
     }
   }
 }

--- a/modules/aws-workspace-basic/versions.tf
+++ b/modules/aws-workspace-basic/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.38.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/aws-workspace-basic/versions.tf
+++ b/modules/aws-workspace-basic/versions.tf
@@ -3,12 +3,12 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = ">=0.5.1"
+      version = ">=1.13.0"
     }
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.58.0"
+      version = ">=5.38.0"
     }
   }
 }

--- a/modules/aws-workspace-with-firewall/versions.tf
+++ b/modules/aws-workspace-with-firewall/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.38.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/aws-workspace-with-firewall/versions.tf
+++ b/modules/aws-workspace-with-firewall/versions.tf
@@ -3,12 +3,12 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = ">=0.5.1"
+      version = ">=1.13.0"
     }
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.58.0"
+      version = ">=5.38.0"
     }
   }
 }

--- a/modules/aws-workspace-with-firewall/workspace.tf
+++ b/modules/aws-workspace-with-firewall/workspace.tf
@@ -21,7 +21,6 @@ resource "time_sleep" "wait" {
 }
 
 resource "databricks_mws_credentials" "this" {
-  account_id       = var.databricks_account_id
   role_arn         = aws_iam_role.cross_account_role.arn
   credentials_name = "${local.prefix}-creds"
   depends_on       = [time_sleep.wait]


### PR DESCRIPTION
Upgrade to > 5 of the `aws` provider, and the latest version of the `databricks` provider.