### PR TITLE
Bump version for AWS VPC module to make it compatible with new AWS provider versions

### DIFF
--- a/modules/aws-databricks-base-infra/vpc.tf
+++ b/modules/aws-databricks-base-infra/vpc.tf
@@ -2,7 +2,7 @@ data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.2.0"
+  version = "5.7.0"
 
   name = var.prefix
   cidr = var.cidr_block
@@ -33,7 +33,7 @@ module "vpc" {
 
 module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "3.2.0"
+  version = "5.7.0"
 
   vpc_id             = module.vpc.vpc_id
   security_group_ids = [module.vpc.default_security_group_id]

--- a/modules/aws-workspace-basic/vpc.tf
+++ b/modules/aws-workspace-basic/vpc.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.2.0"
+  version = "5.7.0"
 
   name = local.prefix
   cidr = var.cidr_block

--- a/modules/aws-workspace-basic/vpc_endpoints.tf
+++ b/modules/aws-workspace-basic/vpc_endpoints.tf
@@ -1,6 +1,6 @@
 module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "3.2.0"
+  version = "5.7.0"
 
   vpc_id             = module.vpc.vpc_id
   security_group_ids = [module.vpc.default_security_group_id]

--- a/modules/aws-workspace-with-firewall/vpc_endpoints.tf
+++ b/modules/aws-workspace-with-firewall/vpc_endpoints.tf
@@ -1,6 +1,6 @@
 module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "3.11.0"
+  version = "5.7.0"
 
   vpc_id             = aws_vpc.db_vpc.id
   security_group_ids = [aws_security_group.default_sg.id]


### PR DESCRIPTION
This fixes #127