### PR TITLE
Updates to `adb-exfiltration-protection` module and example

### DIFF
--- a/examples/adb-exfiltration-protection/README.md
+++ b/examples/adb-exfiltration-protection/README.md
@@ -77,7 +77,6 @@ No modules.
 | [azurerm_storage_account.allowedstorage](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/storage_account)                                              | resource    |
 | [azurerm_storage_account.deniedstorage](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/storage_account)                                               | resource    |
 | [azurerm_subnet.hubfw](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/subnet)                                                                         | resource    |
-| [azurerm_subnet.plsubnet](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/subnet)                                                                      | resource    |
 | [azurerm_subnet.private](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/subnet)                                                                       | resource    |
 | [azurerm_subnet.public](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/subnet)                                                                        | resource    |
 | [azurerm_subnet_network_security_group_association.private](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/subnet_network_security_group_association) | resource    |

--- a/examples/adb-exfiltration-protection/main.tf
+++ b/examples/adb-exfiltration-protection/main.tf
@@ -19,9 +19,9 @@ module "adb-exfiltration-protection" {
   metastore         = var.metastore
   scc_relay         = var.scc_relay
   webapp_ips        = var.webapp_ips
-  extended_infra_ip = var.extended_infra_ip
   dbfs_prefix       = var.dbfs_prefix
   workspace_prefix  = var.workspace_prefix
   firewallfqdn      = var.firewallfqdn
   eventhubs         = var.eventhubs
+  tags              = var.tags
 }

--- a/examples/adb-exfiltration-protection/terraform.tfvars
+++ b/examples/adb-exfiltration-protection/terraform.tfvars
@@ -2,7 +2,11 @@ hubcidr      = "10.178.0.0/20"
 spokecidr    = "10.179.0.0/20"
 no_public_ip = true
 rglocation   = "westeurope"
-metastore = ["consolidated-westeurope-prod-metastore.mysql.database.azure.com",
+# We can pull this information automatically, i.e. from
+# https://github.com/microsoft/AzureTRE/blob/main/templates/workspace_services/databricks/terraform/databricks-udr.json
+# that is maintained by Microsoft team (although it may not be updated immediately).
+metastore = [
+  "consolidated-westeurope-prod-metastore.mysql.database.azure.com",
   "consolidated-westeurope-prod-metastore-addl-1.mysql.database.azure.com",
   "consolidated-westeurope-prod-metastore-addl-2.mysql.database.azure.com",
   "consolidated-westeurope-prod-metastore-addl-3.mysql.database.azure.com",
@@ -12,15 +16,23 @@ metastore = ["consolidated-westeurope-prod-metastore.mysql.database.azure.com",
   "consolidated-westeuropec2-prod-metastore-3.mysql.database.azure.com",
 ]
 // get from https://learn.microsoft.com/en-us/azure/databricks/resources/supported-regions#--metastore-artifact-blob-storage-system-tables-blob-storage-log-blob-storage-and-event-hub-endpoint-ip-addresses
-scc_relay  = ["tunnel.westeurope.azuredatabricks.net", "tunnel.westeuropec2.azuredatabricks.net"]
-webapp_ips = ["52.230.27.216/32", "40.74.30.80/32"]
-eventhubs = ["prod-westeurope-observabilityeventhubs.servicebus.windows.net",
+scc_relay = [
+  "tunnel.westeurope.azuredatabricks.net",
+  "tunnel.westeuropec2.azuredatabricks.net"
+]
+webapp_ips = [
+  "52.232.19.246/32",
+  "40.74.30.80/32",
+  "20.103.219.240/28",
+  "4.150.168.160/28",
+]
+eventhubs = [
+  "prod-westeurope-observabilityeventhubs.servicebus.windows.net",
   "prod-westeuc2-observabilityeventhubs.servicebus.windows.net",
 ]
-extended_infra_ip = "20.73.215.48/28"
 dbfs_prefix       = "dbfs"
 workspace_prefix  = "adb"
-firewallfqdn = [                                 // dbfs rule will be added - depends on dbfs storage name
+firewallfqdn = [ // dbfs rule will be added - depends on dbfs storage name
   "dbartifactsprodwesteu.blob.core.windows.net", //databricks artifacts
   "arprodwesteua1.blob.core.windows.net",
   "arprodwesteua2.blob.core.windows.net",
@@ -47,7 +59,7 @@ firewallfqdn = [                                 // dbfs rule will be added - de
   "arprodwesteua23.blob.core.windows.net",
   "arprodwesteua24.blob.core.windows.net",
   "dbartifactsprodnortheu.blob.core.windows.net", //databricks artifacts secondary
-  "ucstprdwesteu.blob.core.windows.net",          // system tables storage
+  "ucstprdwesteu.dfs.core.windows.net",          // system tables storage
   "dblogprodwesteurope.blob.core.windows.net",    //log blob
   "cdnjs.com",                                    //ganglia
   // Azure monitor

--- a/examples/adb-exfiltration-protection/variables.tf
+++ b/examples/adb-exfiltration-protection/variables.tf
@@ -36,11 +36,6 @@ variable "webapp_ips" {
   type        = list(string)
 }
 
-variable "extended_infra_ip" {
-  description = "IP range for Azure Databricks extended infrastructure"
-  type        = string
-}
-
 variable "eventhubs" {
   description = "List of FQDNs for Azure Databricks EventHubs traffic"
   type        = list(string)
@@ -61,4 +56,10 @@ variable "workspace_prefix" {
 variable "firewallfqdn" {
   type        = list(any)
   description = "List of domains names to put into application rules for handling of HTTPS traffic (Databricks storage accounts, etc.)"
+}
+
+variable "tags" {
+  description = "Additional tags to add to created resources"
+  default     = {}
+  type        = map(string)
 }

--- a/modules/adb-exfiltration-protection/README.md
+++ b/modules/adb-exfiltration-protection/README.md
@@ -43,7 +43,6 @@ In `variables.tfvars`, set these variables (bigger regions have multiple instanc
 metastore         = ["consolidated-westeurope-prod-metastore.mysql.database.azure.com"]
 scc_relay         = ["tunnel.westeurope.azuredatabricks.net"]
 webapp_ips        = ["52.230.27.216/32"] # given at UDR page
-extended_infra_ip = "20.73.215.48/28"
 eventhubs         = ["prod-westeurope-observabilityeventhubs.servicebus.windows.net"]
 # find these for your region, follow Databricks blog tutorial.
 firewallfqdn = ["dbartifactsprodseap.blob.core.windows.net","dbartifactsprodeap.blob.core.windows.net","dblogprodseasia.blob.core.windows.net","cdnjs.com"]
@@ -85,7 +84,6 @@ No modules.
 | [azurerm_storage_account.allowedstorage](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/storage_account)                                              | resource    |
 | [azurerm_storage_account.deniedstorage](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/storage_account)                                               | resource    |
 | [azurerm_subnet.hubfw](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/subnet)                                                                         | resource    |
-| [azurerm_subnet.plsubnet](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/subnet)                                                                      | resource    |
 | [azurerm_subnet.private](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/subnet)                                                                       | resource    |
 | [azurerm_subnet.public](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/subnet)                                                                        | resource    |
 | [azurerm_subnet_network_security_group_association.private](https://registry.terraform.io/providers/hashicorp/azurerm/2.83.0/docs/resources/subnet_network_security_group_association) | resource    |
@@ -106,7 +104,6 @@ No modules.
 | -------------------------------------------------------------------------------------------------------------- | ----------- | ----------- | ----------------- | :------: |
 | <a name="input_bypass_scc_relay"></a> [bypass\_scc\_relay](#input\_bypass\_scc\_relay)                         | n/a         | `bool`      | `true`          |    no    |
 | <a name="input_dbfs_prefix"></a> [dbfs\_prefix](#input\_dbfs\_prefix)                                          | n/a         | `string`    | `"dbfs"`          |    no    |
-| <a name="input_extended_infra_ip"></a> [extended_infra_ip](#input\_extended_infra_ip)                          | n/a         | `string` | n/a               |   yes    |
 | <a name="input_eventhubs"></a> [eventhubs](#input\_eventhubs)                                                  | n/a         | `list(string)` | n/a               |   yes    |
 | <a name="input_firewallfqdn"></a> [firewallfqdn](#input\_firewallfqdn)                                         | n/a         | `list(string)` | n/a               |   yes    |
 | <a name="input_hubcidr"></a> [hubcidr](#input\_hubcidr)                                                        | n/a         | `string`    | `"10.178.0.0/20"` |    no    |

--- a/modules/adb-exfiltration-protection/firewall.tf
+++ b/modules/adb-exfiltration-protection/firewall.tf
@@ -59,26 +59,11 @@ resource "azurerm_firewall_network_rule_collection" "adbfnetwork" {
     ]
 
     destination_ports = [
-      "443", "8443", "8444",
+      "443", "8443–8451",
     ]
 
     destination_addresses = var.webapp_ips
 
-    protocols = [
-      "TCP",
-    ]
-  }
-
-  rule {
-    name = "databricks-extended_infra"
-
-    source_addresses = [
-      join(", ", azurerm_subnet.public.address_prefixes),
-      join(", ", azurerm_subnet.private.address_prefixes),
-    ]
-
-    destination_addresses = [var.extended_infra_ip]
-    destination_ports     = ["*"]
     protocols = [
       "TCP",
     ]

--- a/modules/adb-exfiltration-protection/variables.tf
+++ b/modules/adb-exfiltration-protection/variables.tf
@@ -36,11 +36,6 @@ variable "webapp_ips" {
   type        = list(string)
 }
 
-variable "extended_infra_ip" {
-  description = "IP range for Azure Databricks extended infrastructure"
-  type        = string
-}
-
 variable "eventhubs" {
   description = "List of FQDNs for Azure Databricks EventHubs traffic"
   type        = list(string)

--- a/modules/adb-exfiltration-protection/vnet.tf
+++ b/modules/adb-exfiltration-protection/vnet.tf
@@ -46,9 +46,6 @@ resource "azurerm_subnet" "private" {
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [cidrsubnet(local.cidr, 3, 1)]
 
-  private_endpoint_network_policies_enabled     = true
-  private_link_service_network_policies_enabled = true
-
   delegation {
     name = "databricks"
     service_delegation {
@@ -68,14 +65,6 @@ resource "azurerm_subnet_network_security_group_association" "private" {
   network_security_group_id = azurerm_network_security_group.this.id
 }
 
-
-resource "azurerm_subnet" "plsubnet" {
-  name                 = "${local.prefix}-privatelink"
-  resource_group_name  = azurerm_resource_group.this.name
-  virtual_network_name = azurerm_virtual_network.this.name
-  address_prefixes     = [cidrsubnet(local.cidr, 3, 2)]
-  //private_endpoint_network_policies_enabled = true // set to true to disable subnet policy
-}
 
 resource "azurerm_virtual_network" "hubvnet" {
   name                = "${local.prefix}-hub-vnet"


### PR DESCRIPTION
Changes include:

* removed `plsubnet` resource as it's not necessary here
* removed PL-related network settings
* we don't need `extended_infra_ip` anymore
* added `tags` variable to the example