### PR TITLE
Don't use `~` version spec in modules, use `>=` instead

### DIFF
--- a/modules/aws-workspace-basic/versions.tf
+++ b/modules/aws-workspace-basic/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/modules/aws-workspace-with-firewall/versions.tf
+++ b/modules/aws-workspace-with-firewall/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
Otherwise, people can't use the higher versions of corresponding modules

Fixes #136