### PR TITLE
[Fix] Invert creation of storage credential and metastore

### DIFF
--- a/modules/aws-databricks-unity-catalog/README.md
+++ b/modules/aws-databricks-unity-catalog/README.md
@@ -1,0 +1,10 @@
+# Module aws-databricks-unity-catalog
+
+## Description
+
+This module creates a Databricks Unity Catalog Metastore and Storage Credential for said metastore. It automatically creates an IAM role suitable for Unity Catalog and attaches it to the newly created metastore.
+
+## Required Providers
+
+- `databricks` - only account-level providers are supported.
+- `aws`

--- a/modules/aws-databricks-unity-catalog/main.tf
+++ b/modules/aws-databricks-unity-catalog/main.tf
@@ -3,46 +3,21 @@ locals {
   iam_role_arn = "arn:aws:iam::${var.aws_account_id}:role/${local.iam_role_name}"
 }
 
-resource "databricks_storage_credential" "this" {
-  name = "unity_catalog_storage_credential"
-  aws_iam_role {
-    role_arn = local.iam_role_arn
-  }
-  comment = "Managed by TF"
-  skip_validation = true  # the IAM role is not yet created
-}
-
 resource "databricks_metastore" "this" {
   name          = local.metastore_name
   region        = var.region
   owner         = var.unity_metastore_owner
   storage_root  = "s3://${aws_s3_bucket.metastore.id}/metastore"
-  storage_root_credential_id = databricks_storage_credential.this.id
   force_destroy = true
-
-  # The IAM role referenced in the storage credential must exist before creating the metastore.
-  depends_on = [ aws_iam_role.metastore_data_access ]
 }
 
 resource "databricks_metastore_data_access" "this" {
   metastore_id = databricks_metastore.this.id
-  name         = aws_iam_role.metastore_data_access.name
+  name         = local.iam_role_name
   aws_iam_role {
-    role_arn = aws_iam_role.metastore_data_access.arn
+    role_arn = local.iam_role_arn
   }
   is_default = true
-  depends_on = [
-    resource.time_sleep.wait_role_creation
-  ]
-}
-
-# Sleeping for 20s to wait for the workspace to enable identity federation
-resource "time_sleep" "wait_role_creation" {
-  depends_on = [
-    resource.aws_iam_role.metastore_data_access,
-    resource.databricks_metastore.this
-  ]
-  create_duration = "20s"
 }
 
 resource "databricks_metastore_assignment" "default_metastore" {

--- a/modules/aws-databricks-unity-catalog/main.tf
+++ b/modules/aws-databricks-unity-catalog/main.tf
@@ -1,9 +1,27 @@
+locals {
+  iam_role_name = "${var.prefix}-unity-catalog-metastore-access"
+  iam_role_arn = "arn:aws:iam::${var.aws_account_id}:role/${local.iam_role_name}"
+}
+
+resource "databricks_storage_credential" "this" {
+  name = "unity_catalog_storage_credential"
+  aws_iam_role {
+    role_arn = local.iam_role_arn
+  }
+  comment = "Managed by TF"
+  skip_validation = true  # the IAM role is not yet created
+}
+
 resource "databricks_metastore" "this" {
   name          = local.metastore_name
   region        = var.region
   owner         = var.unity_metastore_owner
   storage_root  = "s3://${aws_s3_bucket.metastore.id}/metastore"
+  storage_root_credential_id = databricks_storage_credential.this.id
   force_destroy = true
+
+  # The IAM role referenced in the storage credential must exist before creating the metastore.
+  depends_on = [ aws_iam_role.metastore_data_access ]
 }
 
 resource "databricks_metastore_data_access" "this" {

--- a/modules/aws-databricks-unity-catalog/uc_cross_account_role.tf
+++ b/modules/aws-databricks-unity-catalog/uc_cross_account_role.tf
@@ -12,7 +12,6 @@ data "aws_iam_policy_document" "passrole_for_uc" {
       test     = "StringEquals"
       variable = "sts:ExternalId"
       values   = [databricks_metastore_data_access.this.aws_iam_role.0.external_id]
-
     }
   }
 
@@ -101,4 +100,10 @@ resource "aws_iam_role" "metastore_data_access" {
   tags = merge(var.tags, {
     Name = "${var.prefix}-unity-catalog IAM role"
   })
+}
+
+# Sleeping for 20s to wait for the workspace to enable identity federation
+resource "time_sleep" "wait_role_creation" {
+  depends_on = [aws_iam_role.metastore_data_access]
+  create_duration = "20s"
 }

--- a/modules/aws-databricks-unity-catalog/uc_cross_account_role.tf
+++ b/modules/aws-databricks-unity-catalog/uc_cross_account_role.tf
@@ -95,7 +95,7 @@ resource "aws_iam_policy" "sample_data" {
 }
 
 resource "aws_iam_role" "metastore_data_access" {
-  name                = "${local.iam_role_name}"
+  name                = local.iam_role_name
   assume_role_policy  = data.aws_iam_policy_document.passrole_for_uc.json
   managed_policy_arns = [aws_iam_policy.unity_metastore.arn, aws_iam_policy.sample_data.arn]
   tags = merge(var.tags, {

--- a/modules/aws-databricks-unity-catalog/uc_cross_account_role.tf
+++ b/modules/aws-databricks-unity-catalog/uc_cross_account_role.tf
@@ -11,7 +11,8 @@ data "aws_iam_policy_document" "passrole_for_uc" {
     condition {
       test     = "StringEquals"
       variable = "sts:ExternalId"
-      values   = [databricks_storage_credential.this.aws_iam_role.external_id]
+      values   = [databricks_metastore_data_access.this.aws_iam_role.0.external_id]
+
     }
   }
 

--- a/modules/aws-databricks-unity-catalog/variables.tf
+++ b/modules/aws-databricks-unity-catalog/variables.tf
@@ -6,7 +6,7 @@ variable "tags" {
 
 variable "prefix" {
   type        = string
-  description = "(Optional) Prefix to name the resources created by this module"
+  description = "(Required) Prefix to name the resources created by this module"
 }
 
 variable "region" {


### PR DESCRIPTION
Historically, the external ID was well-known (the account ID) when storage credentials were created by account admins. Now that storage credentials can be created by non-admins, we want to show an example where the storage credential's external ID is propagated to the IAM role. This does have the strange side effect that we need to know the IAM role ARN before the IAM role itself is created, but because that follows a fixed pattern provided the AWS partition, account ID and role name, that is possible.