### PR TITLE
Update adb-with-private-links-standard to use azurerm v4

### DIFF
--- a/examples/adb-with-private-link-standard/README.md
+++ b/examples/adb-with-private-link-standard/README.md
@@ -24,3 +24,7 @@ This example can be used to deploy the following:
 2. (Optional) Configure your [remote backend](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm)
 3. Run `terraform init` to initialize terraform and get provider ready.
 4. Run `terraform apply` to create the resources.
+
+## How to test
+
+Public access to the workspace deployed here is not allowed by default. If you can establish a direct network connection to the VNet into which the workspace is deployed then you should be able to browse the workspace directly. Alternatively, a virtual machine is created as part of this deployment allowing you to connect to the workspace in case you don't have direct network path to the VNet in which the workspace is deployed. You can use the `test_vm_public_ip` and `test_vm_password` to log into this VM (password value is marked as `sensitive` but can be found in the `teraform.tfstate` file). By default, access to this machine is only allowed from the deployer's public IP address. To allow access from other sources, extra rules can be added to the Network Security Group created for the VM as part of this deployment.

--- a/examples/adb-with-private-link-standard/main.tf
+++ b/examples/adb-with-private-link-standard/main.tf
@@ -1,5 +1,5 @@
 module "adb-with-private-link-standard" {
-  source       = "github.com/databricks/terraform-databricks-examples/modules/adb-with-private-link-standard"
+  source       = "../../modules/adb-with-private-link-standard"
   cidr_transit = var.cidr_transit
   cidr_dp      = var.cidr_dp
   location     = var.location

--- a/examples/adb-with-private-link-standard/outputs.tf
+++ b/examples/adb-with-private-link-standard/outputs.tf
@@ -3,3 +3,18 @@ output "test_vm_password" {
   value       = module.adb-with-private-link-standard.test_vm_password
   sensitive   = true
 }
+
+output "test_vm_public_ip" {
+  description = "Public IP of the Azure VM created for testing"
+  value       = module.adb-with-private-link-standard.test_vm_public_ip
+}
+
+output "workspace_id" {
+  description = "The Databricks workspace ID"
+  value       = module.adb-with-private-link-standard.workspace_id
+}
+
+output "workspace_url" {
+  description = "The Databricks workspace URL"
+  value       = module.adb-with-private-link-standard.workspace_url
+}

--- a/examples/adb-with-private-link-standard/providers.tf
+++ b/examples/adb-with-private-link-standard/providers.tf
@@ -2,11 +2,12 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.104.0"
+      version = ">=4.0.0"
     }
   }
 }
 
 provider "azurerm" {
+  subscription_id = var.subscription_id
   features {}
 }

--- a/examples/adb-with-private-link-standard/terraform.tfvars
+++ b/examples/adb-with-private-link-standard/terraform.tfvars
@@ -1,3 +1,4 @@
+subscription_id  = "<your Azure Subscription ID here>"
 cidr_transit = "10.178.0.0/20"
 cidr_dp      = "10.179.0.0/20"
 location     = "westeurope"

--- a/examples/adb-with-private-link-standard/variables.tf
+++ b/examples/adb-with-private-link-standard/variables.tf
@@ -1,3 +1,8 @@
+variable "subscription_id" {
+  type        = string
+  description = "Azure Subscription ID to deploy the workspace into"
+}
+
 variable "cidr_transit" {
   type        = string
   description = "(Required) The CIDR for the Azure transit VNet"

--- a/modules/adb-with-private-link-standard/databricks_workspace.tf
+++ b/modules/adb-with-private-link-standard/databricks_workspace.tf
@@ -9,7 +9,6 @@ resource "azurerm_databricks_workspace" "dp_workspace" {
   network_security_group_rules_required = "NoAzureDatabricksRules"
   customer_managed_key_enabled          = true
   custom_parameters {
-    no_public_ip                                         = true
     virtual_network_id                                   = azurerm_virtual_network.dp_vnet.id
     private_subnet_name                                  = azurerm_subnet.dp_private.name
     public_subnet_name                                   = azurerm_subnet.dp_public.name

--- a/modules/adb-with-private-link-standard/main.tf
+++ b/modules/adb-with-private-link-standard/main.tf
@@ -12,7 +12,6 @@ data "external" "me" {
 }
 
 locals {
-  // dltp - databricks labs terraform provider
   prefix   = join("-", ["tfdemo", "${random_string.naming.result}"])
   dbfsname = join("", ["dbfs", "${random_string.naming.result}"]) // dbfs name must not have special chars
 

--- a/modules/adb-with-private-link-standard/outputs.tf
+++ b/modules/adb-with-private-link-standard/outputs.tf
@@ -1,15 +1,30 @@
 output "dp_databricks_azure_workspace_resource_id" {
-  description = "The ID of the Databricks Workspace in the Azure management plane."
+  description = "**Depricated** The ID of the Databricks Workspace in the Azure management plane."
   value       = azurerm_databricks_workspace.dp_workspace.id
 }
 
 output "dp_workspace_url" {
   value       = "https://${azurerm_databricks_workspace.dp_workspace.workspace_url}/"
-  description = "The workspace URL which is of the format 'adb-{workspaceId}.{random}.azuredatabricks.net'"
+  description = "**Depricated** Renamed to `workspace_url` to align with naming used in other modules"
+}
+
+output "test_vm_public_ip" {
+  value       = azurerm_public_ip.testvmpublicip.ip_address
+  description = "Public IP of the created virtual machine"
 }
 
 output "test_vm_password" {
   description = "Password to access the Test VM, use `terraform output -json test_vm_password` to get the password value"
   value       = azurerm_windows_virtual_machine.testvm.admin_password
   sensitive   = true
+}
+
+output "workspace_url" {
+  value       = "https://${azurerm_databricks_workspace.dp_workspace.workspace_url}/"
+  description = "The workspace URL which is of the format 'adb-{workspaceId}.{random}.azuredatabricks.net'"
+}
+
+output "workspace_id" {
+  description = "The Databricks workspace ID"
+  value       = azurerm_databricks_workspace.dp_workspace.workspace_id
 }

--- a/modules/adb-with-private-link-standard/providers.tf
+++ b/modules/adb-with-private-link-standard/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.104.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/adb-with-private-link-standard/testvm_transit.tf
+++ b/modules/adb-with-private-link-standard/testvm_transit.tf
@@ -30,10 +30,7 @@ resource "azurerm_network_interface_security_group_association" "testvmnsgassoc"
 }
 
 data "http" "my_public_ip" { // add your host machine ip into nsg
-  url = "https://ifconfig.co/json"
-  request_headers = {
-    Accept = "application/json"
-  }
+  url = "https://ipinfo.io"
 }
 
 locals {
@@ -53,7 +50,7 @@ resource "azurerm_network_security_rule" "test0" {
   source_port_range           = "*"
   destination_port_range      = "3389"
   source_address_prefixes     = [local.ifconfig_co_json.ip]
-  destination_address_prefix  = "VirtualNetwork"
+  destination_address_prefix  = azurerm_public_ip.testvmpublicip.ip_address
   network_security_group_name = azurerm_network_security_group.testvm-nsg.name
   resource_group_name         = azurerm_resource_group.transit_rg.name
 }


### PR DESCRIPTION
One of several updates to existing templates to make them compatible with azurerm v4, tracked in #144

Changes:

- Add `subscription_id` parameter: it is mandatory in azurerm v4
- Remove `no_public_ip` and imposed the minimum on azurerm to be v4 in the module: it is true by default in azurerm v4 
- Add extra output variables in line with other templates
- Change the URL used to get the deployer's IP - it was getting IPv6 preventing RDP access
- Update README.md - added instructions to get via VM

Deployment was fully tested