### PR TITLE
Restrict azurerm version in modules

### DIFF
--- a/modules/adb-lakehouse/providers.tf
+++ b/modules/adb-lakehouse/providers.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/adb-with-private-links-exfiltration-protection/providers.tf
+++ b/modules/adb-with-private-links-exfiltration-protection/providers.tf
@@ -3,6 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
+      version = ">=4.0.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
To prevent undesired outcome in case the parent template tries using the azurerm with lower version because of AzureDatabricks workspace`no_public_ip` default value changed in azurerm v4.0 to be `true` by default. Otherwise there is a risk of deploying a workspace with Public IP unintentionally