### PR TITLE
Change deprecated arguments  (default_catalog_name, acl, versioning)

### DIFF
--- a/examples/adb-uc/stage_3_spn_deploys_uc/metastore.tf
+++ b/examples/adb-uc/stage_3_spn_deploys_uc/metastore.tf
@@ -19,5 +19,10 @@ resource "databricks_metastore_data_access" "first" {
 resource "databricks_metastore_assignment" "this" {
   workspace_id         = local.databricks_workspace_id
   metastore_id         = databricks_metastore.this.id
-  default_catalog_name = "hive_metastore"
+}
+
+resource "databricks_default_namespace_setting" "this" {
+  namespace {
+    value = "main"
+  }
 }

--- a/examples/adb-unity-catalog-basic-demo/modules/metastore-and-users/main.tf
+++ b/examples/adb-unity-catalog-basic-demo/modules/metastore-and-users/main.tf
@@ -93,7 +93,12 @@ resource "databricks_metastore_data_access" "first" {
 resource "databricks_metastore_assignment" "this" {
   workspace_id         = local.databricks_workspace_id
   metastore_id         = databricks_metastore.this.id
-  default_catalog_name = "hive_metastore"
+}
+
+resource "databricks_default_namespace_setting" "this" {
+  namespace {
+    value = "main"
+  }
 }
 
 

--- a/examples/aws-databricks-uc/unity_catalog_infra.tf
+++ b/examples/aws-databricks-uc/unity_catalog_infra.tf
@@ -1,14 +1,22 @@
 // aws resources for UC
 resource "aws_s3_bucket" "metastore" {
   bucket = "${local.prefix}-metastore-jlaw"
-  acl    = "private"
-  versioning {
-    enabled = false
-  }
   force_destroy = true
   tags = merge(var.tags, {
     Name = "${local.prefix}-uc-metastore"
   })
+}
+
+resource "aws_s3_bucket_versioning" "metastore" {
+  bucket = aws_s3_bucket.metastore.id
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_acl" "metastore" {
+  bucket = aws_s3_bucket.metastore.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_public_access_block" "metastore" {

--- a/examples/aws-databricks-uc/workspace_metastore.tf
+++ b/examples/aws-databricks-uc/workspace_metastore.tf
@@ -27,7 +27,12 @@ resource "databricks_metastore_assignment" "default_metastore" {
   for_each             = toset(var.databricks_workspace_ids)
   workspace_id         = each.key
   metastore_id         = databricks_metastore.this.id
-  default_catalog_name = "hive_metastore"
+}
+
+resource "databricks_default_namespace_setting" "this" {
+  namespace {
+    value = "main"
+  }
 }
 
 // metastore - catalog - schema - table

--- a/modules/aws-databricks-unity-catalog/main.tf
+++ b/modules/aws-databricks-unity-catalog/main.tf
@@ -24,5 +24,10 @@ resource "databricks_metastore_assignment" "default_metastore" {
   count                = length(var.databricks_workspace_ids)
   workspace_id         = var.databricks_workspace_ids[count.index]
   metastore_id         = databricks_metastore.this.id
-  default_catalog_name = "hive_metastore"
+}
+
+resource "databricks_default_namespace_setting" "this" {
+  namespace {
+    value = "main"
+  }
 }

--- a/modules/aws-databricks-workspace/main.tf
+++ b/modules/aws-databricks-workspace/main.tf
@@ -1,5 +1,4 @@
 resource "databricks_mws_credentials" "this" {
-  account_id       = var.databricks_account_id
   role_arn         = var.cross_account_role_arn
   credentials_name = "${var.prefix}-creds"
 }


### PR DESCRIPTION
This PR changes the following arguments that are deprecated:

- default_catalog_name on [databricks_metastore_assignment](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/metastore_assignment) 
- acl and versioning on [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket)

I also changed the default catalog name from hive_metastore to main (let me know if that's ok, it doesn't seem to make sense having hive_metastore as the default catalog with UC enabled)

