### PR TITLE
Update variables.tf to include .githubusercontent.com & .github.com

### DIFF
--- a/modules/aws-workspace-with-firewall/variables.tf
+++ b/modules/aws-workspace-with-firewall/variables.tf
@@ -22,7 +22,7 @@ variable "region" {
 }
 
 variable "whitelisted_urls" {
-  default     = [".pypi.org", ".pythonhosted.org", ".cran.r-project.org"]
+  default     = [".pypi.org", ".pythonhosted.org", ".cran.r-project.org", ".githubusercontent.com", ".github.com"]
   description = "List of the domains to allow traffic to"
   type        = list(string)
 }


### PR DESCRIPTION
fix: whitelist required URLs for Databricks CLI in Web Terminal (for DBR 15+)

Explicitly whitelisted two URLs needed for Databricks CLI to function in the Web Terminal. Without this, CLI commands fail with SSL connection timeout (curl: (28)) errors.