### PR TITLE
Update GCP BYOVPC with GCE compute networking

### DIFF
--- a/modules/gcp-workspace-byovpc/README.md
+++ b/modules/gcp-workspace-byovpc/README.md
@@ -1,7 +1,7 @@
 gcp byovpc
 =========================
 
-In this template, we show how to deploy a workspace with a custom vpc.
+In this template, we show how to deploy a workspace with a custom vpc. This template has been updated to reflect the latest changes in Databricks workspace compute usage in GCP. Databricks now [use GCE instead of GKE](https://docs.databricks.com/gcp/en/admin/cloud-configurations/gcp/gce-update) to speed up compute start-up times. Compute on GKE was deprecated on 17 March 2025.
 
 
 ## Requirements

--- a/modules/gcp-workspace-byovpc/init.tf
+++ b/modules/gcp-workspace-byovpc/init.tf
@@ -12,10 +12,8 @@ terraform {
 data "google_client_openid_userinfo" "me" {
 }
 
-
 data "google_client_config" "current" {
 }
-
 
 resource "random_string" "suffix" {
   special = false

--- a/modules/gcp-workspace-byovpc/variables.tf
+++ b/modules/gcp-workspace-byovpc/variables.tf
@@ -24,16 +24,6 @@ variable "subnet_ip_cidr_range" {
   description = "IP Range for Nodes subnet (primary)"
 }
 
-variable "pod_ip_cidr_range" {
-  type        = string
-  description = "IP Range for Pods subnet (secondary)"
-}
-
-variable "svc_ip_cidr_range" {
-  type        = string
-  description = "IP Range for Services subnet (secondary)"
-}
-
 variable "subnet_name" {
   type        = string
   description = "Name of the subnet to create"

--- a/modules/gcp-workspace-byovpc/vpc.tf
+++ b/modules/gcp-workspace-byovpc/vpc.tf
@@ -9,14 +9,6 @@ resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" 
   ip_cidr_range = var.subnet_ip_cidr_range
   region        = var.google_region
   network       = google_compute_network.dbx_private_vpc.id
-  secondary_ip_range {
-    range_name    = "pods"
-    ip_cidr_range = var.pod_ip_cidr_range
-  }
-  secondary_ip_range {
-    range_name    = "svc"
-    ip_cidr_range = var.svc_ip_cidr_range
-  }
   private_ip_google_access = true
 }
 
@@ -44,7 +36,5 @@ resource "databricks_mws_networks" "databricks_network" {
     vpc_id                = google_compute_network.dbx_private_vpc.name
     subnet_id             = google_compute_subnetwork.network-with-private-secondary-ip-ranges.name
     subnet_region         = google_compute_subnetwork.network-with-private-secondary-ip-ranges.region
-    pod_ip_range_name     = "pods"
-    service_ip_range_name = "svc"
   }
 }

--- a/modules/gcp-workspace-byovpc/workspace.tf
+++ b/modules/gcp-workspace-byovpc/workspace.tf
@@ -10,10 +10,6 @@ resource "databricks_mws_workspaces" "databricks_workspace" {
   }
 
   network_id = databricks_mws_networks.databricks_network.network_id
-  gke_config {
-    connectivity_type = "PRIVATE_NODE_PUBLIC_MASTER"
-    master_ip_range   = "10.3.0.0/28"
-  }
 
   token {
     comment = "Terraform token"
@@ -22,5 +18,3 @@ resource "databricks_mws_workspaces" "databricks_workspace" {
   # this makes sure that the NAT is created for outbound traffic before creating the workspace
   depends_on = [google_compute_router_nat.nat]
 }
-
-


### PR DESCRIPTION
I am updating this repository with few updates:
- updated vpc and workspace to reflect using GCE as compute. GKE is deprecated since 17 March 2025
- updated the README.md to reflect the change
- GKE deprecated is reflected in databricks version `1.82.0`